### PR TITLE
Fix job flow and tests

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -46,7 +46,7 @@ class TestYTToJellyfin(unittest.TestCase):
         with patch('pathlib.Path.mkdir') as mock_mkdir:
             folder = self.app.create_folder_structure("Test Show", "01")
             self.assertTrue(mock_mkdir.called)
-            self.assertTrue("Test Show/Season 01" in folder)
+            self.assertTrue("Test_Show/Season 01" in folder)
     
     def test_config_loading(self):
         # Skip this test for now, will need to be revised

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -65,7 +65,8 @@ class TestIntegration(unittest.TestCase):
             "https://youtube.com/playlist?list=TEST",
             "Test Show",
             "01",
-            "01"
+            "01",
+            start_thread=False
         )
         
         # Process the job
@@ -87,7 +88,7 @@ class TestIntegration(unittest.TestCase):
         mock_process_metadata.assert_called_once()
         mock_convert.assert_called_once()
         mock_generate_artwork.assert_called_once()
-        mock_create_nfo_files.assert_called_once()
+        mock_create_nfo.assert_called_once()
     
     @patch('app.YTToJellyfin.download_playlist')
     def test_workflow_with_download_failure(self, mock_download):
@@ -100,7 +101,8 @@ class TestIntegration(unittest.TestCase):
             "https://youtube.com/playlist?list=TEST",
             "Test Show",
             "01",
-            "01"
+            "01",
+            start_thread=False
         )
         
         # Process the job
@@ -122,7 +124,8 @@ class TestIntegration(unittest.TestCase):
             "https://youtube.com/playlist?list=TEST",
             "Test Show",
             "01",
-            "01"
+            "01",
+            start_thread=False
         )
         
         # Process the job
@@ -140,7 +143,8 @@ class TestIntegration(unittest.TestCase):
             "https://youtube.com/playlist?list=TEST",
             "Test Show",
             "01",
-            "invalid"  # Non-numeric value
+            "invalid",  # Non-numeric value
+            start_thread=False
         )
         
         # Process the job


### PR DESCRIPTION
## Summary
- ensure sanitize_name replaces spaces for consistent folder naming
- break after renaming video file once
- validate episode start before downloading and allow disabling thread start
- adjust tests to use start_thread option and expect new folder naming

## Testing
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6844772dd45c832380ea5bd07a3dc4f4