### PR TITLE
Fix slow job details

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -63,8 +63,8 @@ class TestAPIEndpoints(unittest.TestCase):
         """Test getting list of jobs"""
         # Add test jobs
         ytj.jobs = {
-            'job1': MagicMock(to_dict=lambda: {'job_id': 'job1', 'status': 'completed'}),
-            'job2': MagicMock(to_dict=lambda: {'job_id': 'job2', 'status': 'in_progress'})
+            'job1': MagicMock(to_dict=lambda **kwargs: {'job_id': 'job1', 'status': 'completed'}),
+            'job2': MagicMock(to_dict=lambda **kwargs: {'job_id': 'job2', 'status': 'in_progress'})
         }
         
         response = self.client.get('/jobs')
@@ -79,8 +79,8 @@ class TestAPIEndpoints(unittest.TestCase):
         """Test getting details of a specific job"""
         # Add test job
         ytj.jobs = {
-            'job1': MagicMock(to_dict=lambda: {
-                'job_id': 'job1', 
+            'job1': MagicMock(to_dict=lambda **kwargs: {
+                'job_id': 'job1',
                 'status': 'completed',
                 'show_name': 'Test Show'
             })


### PR DESCRIPTION
## Summary
- send limited log messages from API
- strip log messages when listing jobs
- fix tests for new API behavior

## Testing
- `pip install -r requirements.txt`
- `python run_tests.py --type all`

------
https://chatgpt.com/codex/tasks/task_e_6844863a7ec8832398b9b61a75d583d1