### PR TITLE
Fix Python 3.9 compatibility for CI

### DIFF
--- a/app.py
+++ b/app.py
@@ -99,7 +99,7 @@ class DownloadJob:
 
         self.updated_at = datetime.now()
 
-    def to_dict(self, include_messages: bool = True, message_limit: int | None = None):
+    def to_dict(self, include_messages: bool = True, message_limit: Optional[int] = None):
         """Convert job to dictionary for JSON response.
 
         Parameters


### PR DESCRIPTION
## Summary
- support Python 3.9 type annotations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684492c6980c83239c55addef04ff04b