### PR TITLE
Add automatic release on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true
+          draft: false
+          prerelease: false

--- a/README.md
+++ b/README.md
@@ -208,6 +208,19 @@ The CI workflows ensure that:
 2. The application builds and runs successfully in Docker
 3. Dependencies are automatically kept up-to-date with Dependabot
 
+### Automated Releases
+
+Pushing a tag that starts with `v` (for example `v1.2.3`) automatically
+creates a GitHub release. The release notes are generated from the commit
+history, so simply tag your commit and push the tag:
+
+```bash
+git tag v1.2.3
+git push origin v1.2.3
+```
+
+GitHub Actions will publish the release for you.
+
 ## Contributing
 
 Contributions, issues, and feature requests are welcome! Feel free to check the issues page.


### PR DESCRIPTION
## Summary
- add a release workflow that publishes GitHub releases when a tag is pushed
- document the tagging workflow in the README

## Testing
- `python run_tests.py --type basic`
- `flake8 .` *(fails: many style violations)*

------
https://chatgpt.com/codex/tasks/task_e_68449643b63c8323b9b344da23799a92