### PR TITLE
Show playlist links in web UI

### DIFF
--- a/web/static/script.js
+++ b/web/static/script.js
@@ -316,13 +316,14 @@ function updatePlaylistsTable(data) {
     tbody.innerHTML = '';
     if (data.length === 0) {
         const row = document.createElement('tr');
-        row.innerHTML = '<td colspan="3" class="text-center">No playlists</td>';
+        row.innerHTML = '<td colspan="4" class="text-center">No playlists</td>';
         tbody.appendChild(row);
         return;
     }
     data.forEach(p => {
         const row = document.createElement('tr');
-        row.innerHTML = `<td>${p.show_name}</td><td>${p.season_num}</td><td>${p.last_episode}</td>`;
+        const link = `<a href="${p.url}" target="_blank">${p.url}</a>`;
+        row.innerHTML = `<td>${p.show_name}</td><td>${p.season_num}</td><td>${p.last_episode}</td><td>${link}</td>`;
         tbody.appendChild(row);
     });
 }

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -201,6 +201,7 @@
                             <th>Show</th>
                             <th>Season</th>
                             <th>Last Episode</th>
+                            <th>Playlist URL</th>
                         </tr>
                     </thead>
                     <tbody></tbody>


### PR DESCRIPTION
## Summary
- show playlist URL in playlist table

## Testing
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68449c30bc048323a7151ef333786bc0