### PR TITLE
Fix playlist tracking for single videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A Python application that downloads YouTube playlists and processes them to work
 - **Automated Downloads**: Download entire YouTube playlists with a single command using yt-dlp
 - **Incremental Updates**: Remembers downloaded videos and only grabs new items when a playlist grows
 - **Playlist Update Checker**: Automatically queue jobs when your saved playlists get new videos
+- **Single Video Downloads**: Individual videos are not tracked in the playlist list
 - **Proper Metadata**: Generate NFO files that Jellyfin uses to display episode details
 - **Episode Renumbering**: Set custom starting episode numbers for proper sequencing
 - **H.265 Conversion**: Convert videos to H.265 for better compression and playback performance

--- a/app.py
+++ b/app.py
@@ -378,6 +378,10 @@ class YTToJellyfin:
         pid = self._get_playlist_id(url)
         return os.path.join('config', 'archives', f'{pid}.txt')
 
+    def _is_playlist_url(self, url: str) -> bool:
+        """Return True if the URL looks like a playlist."""
+        return 'list=' in url or '/playlist' in url
+
     def _register_playlist(self, url: str, show_name: str, season_num: str) -> None:
         """Register playlist metadata for incremental downloads."""
         pid = self._get_playlist_id(url)
@@ -1307,8 +1311,9 @@ class YTToJellyfin:
         job_id = str(uuid.uuid4())
         job = DownloadJob(job_id, playlist_url, show_name, season_num, episode_start, playlist_start)
 
-        # Track playlist for incremental downloads
-        self._register_playlist(playlist_url, show_name, season_num)
+        # Track playlist for incremental downloads when a playlist URL is provided
+        if self._is_playlist_url(playlist_url):
+            self._register_playlist(playlist_url, show_name, season_num)
 
         with self.job_lock:
             self.jobs[job_id] = job


### PR DESCRIPTION
## Summary
- avoid registering single video URLs as playlists
- document that single videos aren't tracked in playlist list
- test that playlist registration only runs for playlist URLs

## Testing
- `python run_tests.py --type all`

------
https://chatgpt.com/codex/tasks/task_e_68449f851be083238e58a2ee2b8bcf8d