### PR TITLE
Add episode number parsing and UI column

### DIFF
--- a/app.py
+++ b/app.py
@@ -1425,15 +1425,23 @@ class YTToJellyfin:
 
                 # Get episodes
                 for episode_file in season_dir.glob("*.mp4"):
+                    match = re.search(r"S(\d+)E(\d+)", episode_file.name)
+                    episode_num = int(match.group(2)) if match else None
+
                     episode = {
                         "name": episode_file.stem,
                         "path": str(episode_file),
                         "size": episode_file.stat().st_size,
-                        "modified": datetime.fromtimestamp(episode_file.stat().st_mtime).strftime("%Y-%m-%d %H:%M:%S")
+                        "modified": datetime.fromtimestamp(episode_file.stat().st_mtime).strftime("%Y-%m-%d %H:%M:%S"),
+                        "episode_num": episode_num,
                     }
                     season["episodes"].append(episode)
 
-                season["episodes"].sort(key=lambda e: e["name"])
+                def sort_key(e):
+                    ep_num = e.get("episode_num")
+                    return (ep_num is None, ep_num if ep_num is not None else e["name"])
+
+                season["episodes"].sort(key=sort_key)
                 show["seasons"].append(season)
 
             show["seasons"].sort(key=lambda s: s["name"])

--- a/web/static/script.js
+++ b/web/static/script.js
@@ -642,6 +642,7 @@ function createSeasonCard(season) {
                         <table class="table table-sm">
                             <thead>
                                 <tr>
+                                    <th>#</th>
                                     <th>Episode</th>
                                     <th>Size</th>
                                     <th>Modified</th>
@@ -660,9 +661,10 @@ function createSeasonCard(season) {
 
 function createEpisodeRow(episode) {
     const size = formatFileSize(episode.size);
-    
+
     return `
         <tr>
+            <td>${episode.episode_num !== null && episode.episode_num !== undefined ? episode.episode_num : ''}</td>
             <td>${episode.name}</td>
             <td>${size}</td>
             <td>${formatDate(episode.modified)}</td>


### PR DESCRIPTION
## Summary
- parse episode numbers when listing media
- display episode numbers in media table

## Testing
- `python3 run_tests.py --type all`

------
https://chatgpt.com/codex/tasks/task_e_6844acc7c05883238b224ee5d8f0c9ea