### PR TITLE
Add roadmap and MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Tubarr
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,0 +1,15 @@
+# Roadmap
+
+The following are planned improvements and tasks for Tubarr:
+
+- Separate tracking season/episode position from playlist position so adding a single video to a season does not affect automatic playlist downloads.
+- Display all downloaded episodes in the media library and show a drop-down in the playlist view listing episodes downloaded from that playlist.
+- **Add missing MIT license**. The README references a license but none existed.
+- Implement job cancellation/stop capability so background jobs can be aborted.
+- Provide real-time progress updates using WebSockets or Server-Sent Events instead of polling.
+- Refactor the large `app.py` by splitting logic into separate modules.
+- Add a configurable limit on the number of concurrent jobs.
+- Validate configuration values against a schema when loading.
+- Package the application so it can be installed with `pip`.
+- Increase test coverage for playlist update logic.
+- Continue to improve the media library experience.


### PR DESCRIPTION
## Summary
- add missing MIT LICENSE file for distribution
- document planned improvements in new `roadmap.md`

## Testing
- `flake8 .` *(fails: many existing lint errors)*
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6844b7c67c74832394c99f5e5e27e611