### PR TITLE
Add job cancellation functionality

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,23 +18,38 @@ import subprocess
 from pathlib import Path
 from datetime import datetime
 from typing import Dict, List, Optional, Tuple, Any
-from flask import Flask, render_template, request, jsonify, redirect, url_for, abort, send_from_directory
+from flask import (
+    Flask,
+    render_template,
+    request,
+    jsonify,
+    redirect,
+    url_for,
+    abort,
+    send_from_directory,
+)
 
 # Setup logging
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.StreamHandler(),
-        logging.FileHandler('yt-to-jellyfin.log')
-    ]
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler(), logging.FileHandler("yt-to-jellyfin.log")],
 )
-logger = logging.getLogger('yt-to-jellyfin')
+logger = logging.getLogger("yt-to-jellyfin")
+
 
 class DownloadJob:
     """Class to track the status of a download job."""
 
-    def __init__(self, job_id, playlist_url, show_name, season_num, episode_start, playlist_start=None):
+    def __init__(
+        self,
+        job_id,
+        playlist_url,
+        show_name,
+        season_num,
+        episode_start,
+        playlist_start=None,
+    ):
         self.job_id = job_id
         self.playlist_url = playlist_url
         self.show_name = show_name
@@ -46,6 +61,7 @@ class DownloadJob:
         self.messages = []
         self.created_at = datetime.now()
         self.updated_at = datetime.now()
+        self.process: Optional[subprocess.Popen] = None
 
         # Detailed progress tracking
         self.current_stage = "waiting"
@@ -57,8 +73,18 @@ class DownloadJob:
         # Queue of files remaining to process
         self.remaining_files: List[str] = []
 
-    def update(self, status=None, progress=None, message=None, stage=None, file_name=None,
-               stage_progress=None, total_files=None, processed_files=None, detailed_status=None):
+    def update(
+        self,
+        status=None,
+        progress=None,
+        message=None,
+        stage=None,
+        file_name=None,
+        stage_progress=None,
+        total_files=None,
+        processed_files=None,
+        detailed_status=None,
+    ):
         """Update job status information with detailed progress."""
         if status:
             self.status = status
@@ -89,19 +115,20 @@ class DownloadJob:
                     "generating_artwork": "Generating artwork and thumbnails",
                     "creating_nfo": "Creating NFO files",
                     "completed": "Processing completed",
-                    "failed": "Processing failed"
+                    "failed": "Processing failed",
                 }
                 prefix = f"[{stage_desc.get(stage, stage)}]"
                 message = f"{prefix} {message}"
 
-            self.messages.append({
-                "time": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-                "text": message
-            })
+            self.messages.append(
+                {"time": datetime.now().strftime("%Y-%m-%d %H:%M:%S"), "text": message}
+            )
 
         self.updated_at = datetime.now()
 
-    def to_dict(self, include_messages: bool = True, message_limit: Optional[int] = None):
+    def to_dict(
+        self, include_messages: bool = True, message_limit: Optional[int] = None
+    ):
         """Convert job to dictionary for JSON response.
 
         Parameters
@@ -136,8 +163,9 @@ class DownloadJob:
             "total_files": self.total_files,
             "processed_files": self.processed_files,
             "detailed_status": self.detailed_status,
-            "remaining_files": self.remaining_files
+            "remaining_files": self.remaining_files,
         }
+
 
 class YTToJellyfin:
     """Main application class for YouTube to Jellyfin conversion."""
@@ -149,130 +177,149 @@ class YTToJellyfin:
         self.job_lock = threading.Lock()
 
         # Playlist tracking
-        self.playlists_file = os.path.join('config', 'playlists.json')
+        self.playlists_file = os.path.join("config", "playlists.json")
         self.playlists = self._load_playlists()
         self.update_thread: Optional[threading.Thread] = None
-        if self.config.get('update_checker_enabled'):
+        if self.config.get("update_checker_enabled"):
             self.start_update_checker()
 
     def _load_config(self) -> Dict:
         """Load configuration from environment variables or config file."""
         # Check for a local yt-dlp in the same directory as the script
         script_dir = os.path.dirname(os.path.abspath(__file__))
-        local_ytdlp = os.path.join(script_dir, 'yt-dlp')
+        local_ytdlp = os.path.join(script_dir, "yt-dlp")
         if os.path.exists(local_ytdlp) and os.access(local_ytdlp, os.X_OK):
             ytdlp_default = local_ytdlp
         else:
             # Look for specific yt-dlp paths
             specific_paths = [
-                '/home/marc/Documents/yt-dlp/yt-dlp',  # Marc's path
-                '/usr/local/bin/yt-dlp',               # Common Linux path
-                '/usr/bin/yt-dlp'                      # Alternative Linux path
+                "/home/marc/Documents/yt-dlp/yt-dlp",  # Marc's path
+                "/usr/local/bin/yt-dlp",  # Common Linux path
+                "/usr/bin/yt-dlp",  # Alternative Linux path
             ]
             for path in specific_paths:
                 if os.path.exists(path) and os.access(path, os.X_OK):
                     ytdlp_default = path
                     break
             else:
-                ytdlp_default = 'yt-dlp'
+                ytdlp_default = "yt-dlp"
 
         config = {
-            'output_dir': os.environ.get('OUTPUT_DIR', './media'),
-            'quality': os.environ.get('VIDEO_QUALITY', '1080'),
-            'use_h265': os.environ.get('USE_H265', 'true').lower() == 'true',
-            'crf': int(os.environ.get('CRF', '28')),
-            'ytdlp_path': os.environ.get('YTDLP_PATH', ytdlp_default),
-            'cookies': '',  # Will set this after checking if file exists
-            'completed_jobs_limit': int(os.environ.get('COMPLETED_JOBS_LIMIT', '10')),
-            'web_enabled': os.environ.get('WEB_ENABLED', 'true').lower() == 'true',
-            'web_port': int(os.environ.get('WEB_PORT', '8000')),
-            'web_host': os.environ.get('WEB_HOST', '0.0.0.0'),
+            "output_dir": os.environ.get("OUTPUT_DIR", "./media"),
+            "quality": os.environ.get("VIDEO_QUALITY", "1080"),
+            "use_h265": os.environ.get("USE_H265", "true").lower() == "true",
+            "crf": int(os.environ.get("CRF", "28")),
+            "ytdlp_path": os.environ.get("YTDLP_PATH", ytdlp_default),
+            "cookies": "",  # Will set this after checking if file exists
+            "completed_jobs_limit": int(os.environ.get("COMPLETED_JOBS_LIMIT", "10")),
+            "web_enabled": os.environ.get("WEB_ENABLED", "true").lower() == "true",
+            "web_port": int(os.environ.get("WEB_PORT", "8000")),
+            "web_host": os.environ.get("WEB_HOST", "0.0.0.0"),
             # Automatic playlist update checking
-            'update_checker_enabled': os.environ.get('UPDATE_CHECKER_ENABLED', 'false').lower() == 'true',
-            'update_checker_interval': int(os.environ.get('UPDATE_CHECKER_INTERVAL', '60')),
+            "update_checker_enabled": os.environ.get(
+                "UPDATE_CHECKER_ENABLED", "false"
+            ).lower()
+            == "true",
+            "update_checker_interval": int(
+                os.environ.get("UPDATE_CHECKER_INTERVAL", "60")
+            ),
             # Jellyfin integration settings
-            'jellyfin_enabled': os.environ.get('JELLYFIN_ENABLED', 'false').lower() == 'true',
-            'jellyfin_tv_path': os.environ.get('JELLYFIN_TV_PATH', ''),
-            'jellyfin_host': os.environ.get('JELLYFIN_HOST', ''),
-            'jellyfin_port': os.environ.get('JELLYFIN_PORT', '8096'),
-            'jellyfin_api_key': os.environ.get('JELLYFIN_API_KEY', ''),
+            "jellyfin_enabled": os.environ.get("JELLYFIN_ENABLED", "false").lower()
+            == "true",
+            "jellyfin_tv_path": os.environ.get("JELLYFIN_TV_PATH", ""),
+            "jellyfin_host": os.environ.get("JELLYFIN_HOST", ""),
+            "jellyfin_port": os.environ.get("JELLYFIN_PORT", "8096"),
+            "jellyfin_api_key": os.environ.get("JELLYFIN_API_KEY", ""),
             # Filename cleaning settings
-            'clean_filenames': os.environ.get('CLEAN_FILENAMES', 'true').lower() == 'true',
+            "clean_filenames": os.environ.get("CLEAN_FILENAMES", "true").lower()
+            == "true",
         }
 
         # Check if cookies file from environment variable exists
-        cookies_path = os.environ.get('COOKIES_PATH', '')
+        cookies_path = os.environ.get("COOKIES_PATH", "")
         if cookies_path and os.path.exists(cookies_path):
-            config['cookies'] = cookies_path
+            config["cookies"] = cookies_path
         elif cookies_path:
             logger.warning(f"Cookies file not found at {cookies_path}, ignoring")
 
         # Try to load from config file
-        config_file = os.environ.get('CONFIG_FILE', 'config/config.yml')
+        config_file = os.environ.get("CONFIG_FILE", "config/config.yml")
         if os.path.exists(config_file):
             try:
-                with open(config_file, 'r') as f:
+                with open(config_file, "r") as f:
                     file_config = yaml.safe_load(f)
 
                 if file_config and isinstance(file_config, dict):
                     # Handle nested structure
-                    if 'media' in file_config and isinstance(file_config['media'], dict):
-                        for key, value in file_config['media'].items():
-                            if key == 'output_dir':
-                                config['output_dir'] = value
-                            elif key == 'quality':
-                                config['quality'] = value
-                            elif key == 'use_h265':
-                                config['use_h265'] = value
-                            elif key == 'crf':
-                                config['crf'] = int(value)
-                            elif key == 'clean_filenames':
-                                config['clean_filenames'] = value
+                    if "media" in file_config and isinstance(
+                        file_config["media"], dict
+                    ):
+                        for key, value in file_config["media"].items():
+                            if key == "output_dir":
+                                config["output_dir"] = value
+                            elif key == "quality":
+                                config["quality"] = value
+                            elif key == "use_h265":
+                                config["use_h265"] = value
+                            elif key == "crf":
+                                config["crf"] = int(value)
+                            elif key == "clean_filenames":
+                                config["clean_filenames"] = value
 
                     # Handle top-level keys
-                    if 'cookies_path' in file_config:
-                        cookies_path = file_config['cookies_path']
+                    if "cookies_path" in file_config:
+                        cookies_path = file_config["cookies_path"]
                         # Check if the cookies path exists
                         if os.path.exists(cookies_path):
-                            config['cookies'] = cookies_path
+                            config["cookies"] = cookies_path
                         else:
-                            logger.warning(f"Cookies file not found at {cookies_path}, ignoring")
+                            logger.warning(
+                                f"Cookies file not found at {cookies_path}, ignoring"
+                            )
 
                     # Handle defaults
-                    if 'defaults' in file_config and isinstance(file_config['defaults'], dict):
-                        config['defaults'] = file_config['defaults']
+                    if "defaults" in file_config and isinstance(
+                        file_config["defaults"], dict
+                    ):
+                        config["defaults"] = file_config["defaults"]
 
                     # Handle web settings
-                    if 'web' in file_config and isinstance(file_config['web'], dict):
-                        for key, value in file_config['web'].items():
-                            if key == 'enabled':
-                                config['web_enabled'] = value
-                            elif key == 'port':
-                                config['web_port'] = int(value)
-                            elif key == 'host':
-                                config['web_host'] = value
+                    if "web" in file_config and isinstance(file_config["web"], dict):
+                        for key, value in file_config["web"].items():
+                            if key == "enabled":
+                                config["web_enabled"] = value
+                            elif key == "port":
+                                config["web_port"] = int(value)
+                            elif key == "host":
+                                config["web_host"] = value
 
                     # Handle Jellyfin settings
-                    if 'jellyfin' in file_config and isinstance(file_config['jellyfin'], dict):
-                        for key, value in file_config['jellyfin'].items():
-                            if key == 'enabled':
-                                config['jellyfin_enabled'] = value
-                            elif key == 'tv_path':
-                                config['jellyfin_tv_path'] = value
-                            elif key == 'host':
-                                config['jellyfin_host'] = value
-                            elif key == 'port':
-                                config['jellyfin_port'] = str(value)
-                            elif key == 'api_key':
-                                config['jellyfin_api_key'] = value
+                    if "jellyfin" in file_config and isinstance(
+                        file_config["jellyfin"], dict
+                    ):
+                        for key, value in file_config["jellyfin"].items():
+                            if key == "enabled":
+                                config["jellyfin_enabled"] = value
+                            elif key == "tv_path":
+                                config["jellyfin_tv_path"] = value
+                            elif key == "host":
+                                config["jellyfin_host"] = value
+                            elif key == "port":
+                                config["jellyfin_port"] = str(value)
+                            elif key == "api_key":
+                                config["jellyfin_api_key"] = value
 
                     # Handle playlist update checker settings
-                    if 'update_checker' in file_config and isinstance(file_config['update_checker'], dict):
-                        uc = file_config['update_checker']
-                        if 'enabled' in uc:
-                            config['update_checker_enabled'] = uc['enabled']
-                        if 'interval_minutes' in uc:
-                            config['update_checker_interval'] = int(uc['interval_minutes'])
+                    if "update_checker" in file_config and isinstance(
+                        file_config["update_checker"], dict
+                    ):
+                        uc = file_config["update_checker"]
+                        if "enabled" in uc:
+                            config["update_checker_enabled"] = uc["enabled"]
+                        if "interval_minutes" in uc:
+                            config["update_checker_interval"] = int(
+                                uc["interval_minutes"]
+                            )
 
             except (yaml.YAMLError, IOError) as e:
                 logger.error(f"Error loading config file: {e}")
@@ -282,14 +329,14 @@ class YTToJellyfin:
 
     def check_dependencies(self) -> bool:
         """Check if all required dependencies are installed."""
-        dependencies = ['ffmpeg', 'convert', 'montage']
+        dependencies = ["ffmpeg", "convert", "montage"]
 
         # Special handling for yt-dlp
-        ytdlp_path = self.config['ytdlp_path']
+        ytdlp_path = self.config["ytdlp_path"]
         logger.info(f"Using yt-dlp path: {ytdlp_path}")
 
         # If full path is provided, check if file exists and is executable
-        if ytdlp_path.startswith('/'):
+        if ytdlp_path.startswith("/"):
             if not os.path.exists(ytdlp_path):
                 logger.error(f"yt-dlp not found at path: {ytdlp_path}")
                 return False
@@ -304,7 +351,9 @@ class YTToJellyfin:
         # Check other dependencies
         for cmd in dependencies:
             try:
-                result = subprocess.run(['which', cmd], check=True, capture_output=True, text=True)
+                result = subprocess.run(
+                    ["which", cmd], check=True, capture_output=True, text=True
+                )
                 logger.info(f"Found dependency {cmd} at: {result.stdout.strip()}")
             except subprocess.CalledProcessError:
                 logger.error(f"Required dependency not found: {cmd}")
@@ -317,23 +366,23 @@ class YTToJellyfin:
         # Trim surrounding whitespace
         name = name.strip()
         # Replace underscores with spaces for readability
-        name = name.replace('_', ' ')
+        name = name.replace("_", " ")
         # Remove characters that are invalid on most file systems
-        sanitized = re.sub(r'[\\/:"*?<>|]', '', name)
+        sanitized = re.sub(r'[\\/:"*?<>|]', "", name)
         # Collapse multiple spaces into a single space
-        sanitized = re.sub(r'\s+', ' ', sanitized)
+        sanitized = re.sub(r"\s+", " ", sanitized)
         return sanitized
 
     def clean_filename(self, name: str) -> str:
         """Clean up filename for better readability.
         Replaces underscores with spaces and fixes common formatting issues."""
         # First, preserve episode identifier pattern (S01E01)
-        episode_pattern = r'(S\d+E\d+)'
+        episode_pattern = r"(S\d+E\d+)"
         episode_match = re.search(episode_pattern, name)
 
         if not episode_match:
             # No episode pattern found, just replace underscores
-            return name.replace('_', ' ')
+            return name.replace("_", " ")
 
         # Split name by episode identifier
         parts = re.split(episode_pattern, name, maxsplit=1)
@@ -341,28 +390,28 @@ class YTToJellyfin:
         # Clean up the title part (before episode identifier)
         if len(parts) >= 1 and parts[0]:
             # Replace underscores with spaces
-            parts[0] = parts[0].replace('_', ' ')
+            parts[0] = parts[0].replace("_", " ")
             # Fix spacing around dash
-            parts[0] = re.sub(r'\s*-\s*', ' - ', parts[0])
+            parts[0] = re.sub(r"\s*-\s*", " - ", parts[0])
             # Remove multiple spaces
-            parts[0] = re.sub(r'\s+', ' ', parts[0])
+            parts[0] = re.sub(r"\s+", " ", parts[0])
             # Trim whitespace
             parts[0] = parts[0].strip()
 
         # Reassemble the filename with the episode identifier, ensuring proper spacing
         result = ""
         for i, part in enumerate(parts):
-            if i > 0 and i % 2 == 1 and parts[i-1] and not parts[i-1].endswith(' '):
+            if i > 0 and i % 2 == 1 and parts[i - 1] and not parts[i - 1].endswith(" "):
                 # This is an episode identifier (S01E01) and previous part doesn't end with space
                 result += " " + part
             else:
                 result += part
 
         # Handle case where episode identifier is at start (unlikely but possible)
-        if result.startswith("S") and re.match(r'^S\d+E\d+', result) and len(parts) > 1:
+        if result.startswith("S") and re.match(r"^S\d+E\d+", result) and len(parts) > 1:
             # Add space after episode identifier if next part doesn't start with space
-            if not parts[1].startswith(' '):
-                episode_end = re.match(r'^S\d+E\d+', result).end()
+            if not parts[1].startswith(" "):
+                episode_end = re.match(r"^S\d+E\d+", result).end()
                 result = result[:episode_end] + " " + result[episode_end:]
 
         return result
@@ -371,7 +420,7 @@ class YTToJellyfin:
         """Load stored playlist information from disk."""
         if os.path.exists(self.playlists_file):
             try:
-                with open(self.playlists_file, 'r') as f:
+                with open(self.playlists_file, "r") as f:
                     return json.load(f)
             except (IOError, json.JSONDecodeError):
                 logger.warning("Failed to load playlists file, starting fresh")
@@ -380,42 +429,42 @@ class YTToJellyfin:
     def _save_playlists(self) -> None:
         """Persist playlist information to disk."""
         os.makedirs(os.path.dirname(self.playlists_file), exist_ok=True)
-        with open(self.playlists_file, 'w') as f:
+        with open(self.playlists_file, "w") as f:
             json.dump(self.playlists, f, indent=2)
 
     def _get_playlist_id(self, url: str) -> str:
         """Extract playlist ID from URL."""
-        match = re.search(r'list=([^&]+)', url)
+        match = re.search(r"list=([^&]+)", url)
         if match:
             return match.group(1)
-        return re.sub(r'\W+', '', url)
+        return re.sub(r"\W+", "", url)
 
     def _get_archive_file(self, url: str) -> str:
         """Get the archive file path for a playlist."""
         pid = self._get_playlist_id(url)
-        return os.path.join('config', 'archives', f'{pid}.txt')
+        return os.path.join("config", "archives", f"{pid}.txt")
 
     def _is_playlist_url(self, url: str) -> bool:
         """Return True if the URL looks like a playlist."""
-        return 'list=' in url or '/playlist' in url
+        return "list=" in url or "/playlist" in url
 
     def _register_playlist(self, url: str, show_name: str, season_num: str) -> None:
         """Register playlist metadata for incremental downloads."""
         pid = self._get_playlist_id(url)
         if pid not in self.playlists:
             self.playlists[pid] = {
-                'url': url,
-                'show_name': show_name,
-                'season_num': season_num,
-                'archive': self._get_archive_file(url)
+                "url": url,
+                "show_name": show_name,
+                "season_num": season_num,
+                "archive": self._get_archive_file(url),
             }
             self._save_playlists()
 
     def _get_existing_max_index(self, folder: str, season_num: str) -> int:
         """Return the highest episode index already present in folder."""
-        pattern = re.compile(rf'S{season_num}E(\d+)')
+        pattern = re.compile(rf"S{season_num}E(\d+)")
         max_idx = 0
-        for file in Path(folder).glob(f'*S{season_num}E*.mp4'):
+        for file in Path(folder).glob(f"*S{season_num}E*.mp4"):
             match = pattern.search(file.name)
             if match:
                 max_idx = max(max_idx, int(match.group(1)))
@@ -425,14 +474,14 @@ class YTToJellyfin:
         """Check registered playlists for new videos and create jobs."""
         created_jobs = []
         for pid, info in self.playlists.items():
-            archive = info.get('archive', self._get_archive_file(info['url']))
+            archive = info.get("archive", self._get_archive_file(info["url"]))
             try:
                 result = subprocess.run(
                     [
-                        self.config['ytdlp_path'],
-                        '--flat-playlist',
-                        '--dump-single-json',
-                        info['url'],
+                        self.config["ytdlp_path"],
+                        "--flat-playlist",
+                        "--dump-single-json",
+                        info["url"],
                     ],
                     capture_output=True,
                     text=True,
@@ -443,10 +492,10 @@ class YTToJellyfin:
                 logger.error(f"Failed to check playlist {info['url']}: {e}")
                 continue
 
-            ids = [e.get('id') for e in data.get('entries', []) if e.get('id')]
+            ids = [e.get("id") for e in data.get("entries", []) if e.get("id")]
             archived = set()
             if os.path.exists(archive):
-                with open(archive, 'r') as f:
+                with open(archive, "r") as f:
                     archived = {line.strip() for line in f if line.strip()}
 
             new_ids = [vid for vid in ids if vid not in archived]
@@ -454,13 +503,10 @@ class YTToJellyfin:
                 logger.info(f"No updates found for playlist {info['url']}")
                 continue
 
-            folder = self.create_folder_structure(info['show_name'], info['season_num'])
-            start = self._get_existing_max_index(folder, info['season_num']) + 1
+            folder = self.create_folder_structure(info["show_name"], info["season_num"])
+            start = self._get_existing_max_index(folder, info["season_num"]) + 1
             job_id = self.create_job(
-                info['url'],
-                info['show_name'],
-                info['season_num'],
-                str(start).zfill(2)
+                info["url"], info["show_name"], info["season_num"], str(start).zfill(2)
             )
             created_jobs.append(job_id)
 
@@ -470,7 +516,7 @@ class YTToJellyfin:
         """Start a thread that periodically checks playlists."""
 
         def _run() -> None:
-            interval = self.config.get('update_checker_interval', 60)
+            interval = self.config.get("update_checker_interval", 60)
             while True:
                 try:
                     if self.playlists:
@@ -484,16 +530,29 @@ class YTToJellyfin:
 
     def create_folder_structure(self, show_name: str, season_num: str) -> str:
         """Create the folder structure for the TV show and season."""
-        folder = Path(self.config['output_dir']) / self.sanitize_name(show_name) / f"Season {season_num}"
+        folder = (
+            Path(self.config["output_dir"])
+            / self.sanitize_name(show_name)
+            / f"Season {season_num}"
+        )
         folder.mkdir(parents=True, exist_ok=True)
         return str(folder)
 
-    def download_playlist(self, playlist_url: str, folder: str, season_num: str, job_id: str, playlist_start: Optional[int] = None) -> bool:
+    def download_playlist(
+        self,
+        playlist_url: str,
+        folder: str,
+        season_num: str,
+        job_id: str,
+        playlist_start: Optional[int] = None,
+    ) -> bool:
         """Download a YouTube playlist using yt-dlp."""
-        output_template = f"{folder}/%(title)s S{season_num}E%(playlist_index)02d.%(ext)s"
+        output_template = (
+            f"{folder}/%(title)s S{season_num}E%(playlist_index)02d.%(ext)s"
+        )
 
         # Get the absolute path for yt-dlp
-        ytdlp_path = self.config['ytdlp_path']
+        ytdlp_path = self.config["ytdlp_path"]
         if not os.path.isabs(ytdlp_path):
             # Check if it's in the script directory
             script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -505,37 +564,39 @@ class YTToJellyfin:
 
         cmd = [
             ytdlp_path,
-            '--ignore-errors',
-            '--no-warnings',
+            "--ignore-errors",
+            "--no-warnings",
             f'-f bestvideo[height<={self.config["quality"]}]+bestaudio/best[height<={self.config["quality"]}]',
-            '-o', output_template,
-            '--write-info-json',
-            '--restrict-filenames',
-            '--merge-output-format', 'mp4',
-            '--progress',
-            '--no-cookies-from-browser',  # Don't try to read cookies from browser
-            playlist_url
+            "-o",
+            output_template,
+            "--write-info-json",
+            "--restrict-filenames",
+            "--merge-output-format",
+            "mp4",
+            "--progress",
+            "--no-cookies-from-browser",  # Don't try to read cookies from browser
+            playlist_url,
         ]
 
         # Use download archive to avoid re-downloading existing videos
         archive_file = self._get_archive_file(playlist_url)
         os.makedirs(os.path.dirname(archive_file), exist_ok=True)
-        cmd.extend(['--download-archive', archive_file])
+        cmd.extend(["--download-archive", archive_file])
 
         # Determine playlist starting position
         if playlist_start:
-            cmd.extend(['--playlist-start', str(playlist_start)])
+            cmd.extend(["--playlist-start", str(playlist_start)])
         elif not os.path.exists(archive_file):
             existing_max = self._get_existing_max_index(folder, season_num)
             if existing_max:
-                cmd.extend(['--playlist-start', str(existing_max + 1)])
+                cmd.extend(["--playlist-start", str(existing_max + 1)])
 
-        if self.config['cookies'] and os.path.exists(self.config['cookies']):
+        if self.config["cookies"] and os.path.exists(self.config["cookies"]):
             # Only use cookies file if it exists
             cmd.insert(1, f'--cookies={self.config["cookies"]}')
         else:
             # Add --no-cookies option to prevent trying to save cookies
-            cmd.insert(1, '--no-cookies')
+            cmd.insert(1, "--no-cookies")
 
         job = self.jobs.get(job_id)
         if job:
@@ -545,7 +606,7 @@ class YTToJellyfin:
                 progress=0,
                 stage_progress=0,
                 detailed_status="Starting download of playlist",
-                message=f"Starting download of playlist: {playlist_url}"
+                message=f"Starting download of playlist: {playlist_url}",
             )
 
         logger.info(f"Starting download of playlist: {playlist_url}")
@@ -558,17 +619,22 @@ class YTToJellyfin:
                 cmd,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
-                universal_newlines=True
+                universal_newlines=True,
             )
+            if job:
+                job.process = process
 
             for line in process.stdout:
+                if job and job.status == "cancelled":
+                    process.terminate()
+                    break
                 line = line.strip()
                 logger.info(line)
                 if job:
                     # Extract information about which file is being processed
                     if "[download]" in line and "Destination:" in line:
                         try:
-                            file_match = re.search(r'Destination:\s+(.+)', line)
+                            file_match = re.search(r"Destination:\s+(.+)", line)
                             if file_match:
                                 current_file = os.path.basename(file_match.group(1))
                                 processed_files += 1
@@ -578,7 +644,7 @@ class YTToJellyfin:
                                     file_name=current_file,
                                     processed_files=processed_files,
                                     detailed_status=f"Downloading: {current_file}",
-                                    message=f"Downloading file: {current_file}"
+                                    message=f"Downloading file: {current_file}",
                                 )
                         except (ValueError, AttributeError) as e:
                             logger.error(f"Error parsing destination: {e}")
@@ -586,7 +652,7 @@ class YTToJellyfin:
                     # Extract total files information
                     elif "[download]" in line and "of" in line and "item" in line:
                         try:
-                            total_match = re.search(r'of\s+(\d+)\s+item', line)
+                            total_match = re.search(r"of\s+(\d+)\s+item", line)
                             if total_match:
                                 total_files = int(total_match.group(1))
                                 job.update(total_files=total_files)
@@ -596,15 +662,15 @@ class YTToJellyfin:
                     # Extract progress percentage
                     elif "%" in line:
                         try:
-                            progress_str = re.search(r'(\d+\.\d+)%', line)
+                            progress_str = re.search(r"(\d+\.\d+)%", line)
                             if progress_str:
                                 file_progress = float(progress_str.group(1))
                                 # Overall progress is a combination of which file we're on and its progress
                                 if total_files > 0:
                                     overall_progress = min(
                                         99,
-                                        ((processed_files - 1) / total_files * 100) +
-                                        (file_progress / total_files)
+                                        ((processed_files - 1) / total_files * 100)
+                                        + (file_progress / total_files),
                                     )
                                 else:
                                     overall_progress = file_progress
@@ -613,7 +679,7 @@ class YTToJellyfin:
                                     progress=overall_progress,
                                     stage_progress=file_progress,
                                     message=line,
-                                    detailed_status=f"Downloading: {current_file} ({file_progress:.1f}%)"
+                                    detailed_status=f"Downloading: {current_file} ({file_progress:.1f}%)",
                                 )
                         except (ValueError, AttributeError) as e:
                             logger.error(f"Error parsing progress: {e}")
@@ -623,6 +689,8 @@ class YTToJellyfin:
                         job.update(message=line)
 
             process.wait()
+            if job:
+                job.process = None
 
             if process.returncode != 0:
                 if job:
@@ -630,9 +698,11 @@ class YTToJellyfin:
                         status="failed",
                         stage="failed",
                         detailed_status="Download failed",
-                        message=f"Download failed with return code {process.returncode}"
+                        message=f"Download failed with return code {process.returncode}",
                     )
-                logger.error(f"Error downloading playlist, return code: {process.returncode}")
+                logger.error(
+                    f"Error downloading playlist, return code: {process.returncode}"
+                )
                 return False
 
             if job:
@@ -642,17 +712,25 @@ class YTToJellyfin:
                     progress=100,
                     stage_progress=100,
                     detailed_status="Download completed successfully",
-                    message="Download completed successfully"
+                    message="Download completed successfully",
                 )
             return True
 
         except subprocess.SubprocessError as e:
             if job:
+                job.process = None
                 job.update(status="failed", message=f"Download failed: {str(e)}")
             logger.error(f"Error downloading playlist: {e}")
             return False
 
-    def process_metadata(self, folder: str, show_name: str, season_num: str, episode_start: int, job_id: str) -> None:
+    def process_metadata(
+        self,
+        folder: str,
+        show_name: str,
+        season_num: str,
+        episode_start: int,
+        job_id: str,
+    ) -> None:
         """Process metadata from downloaded videos and create NFO files."""
         job = self.jobs.get(job_id)
         if job:
@@ -662,24 +740,24 @@ class YTToJellyfin:
                 progress=0,
                 stage_progress=0,
                 detailed_status="Processing metadata from videos",
-                message="Processing metadata and creating NFO files"
+                message="Processing metadata and creating NFO files",
             )
 
-        json_files = list(Path(folder).glob('*.info.json'))
+        json_files = list(Path(folder).glob("*.info.json"))
 
         if not json_files:
             if job:
                 job.update(
                     message="Warning: No JSON metadata files found",
-                    detailed_status="No metadata files found"
+                    detailed_status="No metadata files found",
                 )
             logger.warning("No JSON metadata files found")
             return
 
         # Find first index to calculate offset
-        with open(json_files[0], 'r') as f:
+        with open(json_files[0], "r") as f:
             first_data = json.load(f)
-            first_index = first_data.get('playlist_index', 1)
+            first_index = first_data.get("playlist_index", 1)
 
         episode_offset = episode_start - first_index
         total_files = len(json_files)
@@ -687,64 +765,78 @@ class YTToJellyfin:
         if job:
             job.update(
                 total_files=total_files,
-                detailed_status=f"Processing metadata for {total_files} videos"
+                detailed_status=f"Processing metadata for {total_files} videos",
             )
 
         for i, json_file in enumerate(json_files):
-            with open(json_file, 'r') as f:
+            with open(json_file, "r") as f:
                 data = json.load(f)
 
-            title = data.get('title', 'Unknown Title')
-            description = data.get('description', '').split('\n')[0] if data.get('description') else ''
-            upload_date = data.get('upload_date', '')
+            title = data.get("title", "Unknown Title")
+            description = (
+                data.get("description", "").split("\n")[0]
+                if data.get("description")
+                else ""
+            )
+            upload_date = data.get("upload_date", "")
 
             # Format the upload date
             if upload_date:
                 try:
-                    air_date = datetime.strptime(upload_date, '%Y%m%d').strftime('%Y-%m-%d')
+                    air_date = datetime.strptime(upload_date, "%Y%m%d").strftime(
+                        "%Y-%m-%d"
+                    )
                 except ValueError:
-                    air_date = ''
+                    air_date = ""
             else:
-                air_date = ''
+                air_date = ""
 
             # Calculate new episode number
-            original_ep = data.get('playlist_index', 0)
+            original_ep = data.get("playlist_index", 0)
             new_ep = original_ep + episode_offset
             new_ep_padded = f"{new_ep:02d}"
 
             # Create base filename for renaming
-            base_file = str(json_file).replace('.info.json', '')
+            base_file = str(json_file).replace(".info.json", "")
             # Use a lambda function for replacement to avoid issues with backslash handling
             # Match both with and without spaces before the season identifier
-            new_base = re.sub(rf'(\s?)?(S{season_num}E)[0-9]+', lambda m: f"{m.group(1) or ' '}{m.group(2)}{new_ep_padded}", base_file)
+            new_base = re.sub(
+                rf"(\s?)?(S{season_num}E)[0-9]+",
+                lambda m: f"{m.group(1) or ' '}{m.group(2)}{new_ep_padded}",
+                base_file,
+            )
             file_name = os.path.basename(new_base)
 
             if job:
                 job.update(
                     file_name=file_name,
-                    processed_files=i+1,
+                    processed_files=i + 1,
                     detailed_status=f"Processing metadata: {file_name}",
-                    message=f"Processing metadata for {title}"
+                    message=f"Processing metadata for {title}",
                 )
 
             # Rename video files
-            for ext in ['mp4', 'mkv', 'webm']:
+            for ext in ["mp4", "mkv", "webm"]:
                 original = f"{base_file}.{ext}"
                 if os.path.exists(original):
                     # Get the basename without extension
                     basename = os.path.basename(new_base)
 
                     # Check if filename cleaning is enabled
-                    if self.config.get('clean_filenames', True):
+                    if self.config.get("clean_filenames", True):
                         # Clean the filename (replace underscores with spaces)
                         basename = self.clean_filename(basename)
 
                     # Create new path with the potentially cleaned filename
-                    new_file = os.path.join(os.path.dirname(new_base), f"{basename}.{ext}")
+                    new_file = os.path.join(
+                        os.path.dirname(new_base), f"{basename}.{ext}"
+                    )
 
                     os.rename(original, new_file)
                     if job:
-                        job.update(message=f"Renamed file to {os.path.basename(new_file)}")
+                        job.update(
+                            message=f"Renamed file to {os.path.basename(new_file)}"
+                        )
                     break
 
             # Create NFO file
@@ -763,14 +855,14 @@ class YTToJellyfin:
             basename = os.path.basename(new_base)
 
             # Check if filename cleaning is enabled
-            if self.config.get('clean_filenames', True):
+            if self.config.get("clean_filenames", True):
                 # Clean the filename (replace underscores with spaces)
                 basename = self.clean_filename(basename)
 
             # Create NFO path with the potentially cleaned filename
             nfo_file = os.path.join(os.path.dirname(new_base), f"{basename}.nfo")
 
-            with open(nfo_file, 'w') as f:
+            with open(nfo_file, "w") as f:
                 f.write(nfo_content)
 
             if job:
@@ -785,18 +877,18 @@ class YTToJellyfin:
                 job.update(
                     progress=progress,
                     stage_progress=progress,
-                    detailed_status=f"Processed {i+1} of {total_files} files"
+                    detailed_status=f"Processed {i+1} of {total_files} files",
                 )
 
     def convert_video_files(self, folder: str, season_num: str, job_id: str) -> None:
         """Convert video files to H.265 format for better compression."""
-        if not self.config['use_h265']:
+        if not self.config["use_h265"]:
             logger.info("H.265 conversion disabled, skipping")
             job = self.jobs.get(job_id)
             if job:
                 job.update(
                     message="H.265 conversion disabled, skipping",
-                    detailed_status="H.265 conversion disabled"
+                    detailed_status="H.265 conversion disabled",
                 )
             return
 
@@ -808,63 +900,89 @@ class YTToJellyfin:
                 progress=0,
                 stage_progress=0,
                 detailed_status="Preparing video conversion to H.265",
-                message="Starting video conversion to H.265"
+                message="Starting video conversion to H.265",
             )
 
         video_files = []
-        for ext in ['webm', 'mp4']:
-            video_files.extend(list(Path(folder).glob(f'*S{season_num}E*.{ext}')))
+        for ext in ["webm", "mp4"]:
+            video_files.extend(list(Path(folder).glob(f"*S{season_num}E*.{ext}")))
 
         total_files = len(video_files)
         if total_files == 0:
             if job:
                 job.update(
                     message="No video files found for conversion",
-                    detailed_status="No video files to convert"
+                    detailed_status="No video files to convert",
                 )
             return
 
         if job:
             job.update(
                 total_files=total_files,
-                detailed_status=f"Converting {total_files} video files to H.265"
+                detailed_status=f"Converting {total_files} video files to H.265",
             )
 
         for i, video in enumerate(video_files):
-            ext = str(video).rsplit('.', 1)[1].lower()
-            if ext == 'mp4':
+            ext = str(video).rsplit(".", 1)[1].lower()
+            if ext == "mp4":
                 # Check if already H.265
-                probe_cmd = ['ffprobe', '-v', 'error', '-select_streams', 'v:0',
-                            '-show_entries', 'stream=codec_name', '-of', 'json', str(video)]
+                probe_cmd = [
+                    "ffprobe",
+                    "-v",
+                    "error",
+                    "-select_streams",
+                    "v:0",
+                    "-show_entries",
+                    "stream=codec_name",
+                    "-of",
+                    "json",
+                    str(video),
+                ]
                 result = subprocess.run(probe_cmd, capture_output=True, text=True)
-                codec = json.loads(result.stdout).get('streams', [{}])[0].get('codec_name', '')
+                codec = (
+                    json.loads(result.stdout)
+                    .get("streams", [{}])[0]
+                    .get("codec_name", "")
+                )
 
-                if codec in ['hevc', 'h265']:
+                if codec in ["hevc", "h265"]:
                     logger.info(f"Skipping already H.265 encoded file: {video}")
                     if job:
                         job.update(
-                            processed_files=i+1,
-                            message=f"Skipping already H.265 encoded file: {os.path.basename(str(video))}"
+                            processed_files=i + 1,
+                            message=f"Skipping already H.265 encoded file: {os.path.basename(str(video))}",
                         )
                     continue
 
-            base = str(video).rsplit('.', 1)[0]
+            base = str(video).rsplit(".", 1)[0]
             temp_file = f"{base}.temp.mp4"
 
             cmd = [
-                'ffmpeg', '-i', str(video),
-                '-c:v', 'libx265', '-preset', 'medium',
-                '-crf', str(self.config['crf']), '-tag:v', 'hvc1',
-                '-c:a', 'aac', '-b:a', '128k', temp_file
+                "ffmpeg",
+                "-i",
+                str(video),
+                "-c:v",
+                "libx265",
+                "-preset",
+                "medium",
+                "-crf",
+                str(self.config["crf"]),
+                "-tag:v",
+                "hvc1",
+                "-c:a",
+                "aac",
+                "-b:a",
+                "128k",
+                temp_file,
             ]
 
             filename = os.path.basename(str(video))
             if job:
                 job.update(
                     file_name=filename,
-                    processed_files=i+1,
+                    processed_files=i + 1,
                     detailed_status=f"Converting {filename} to H.265 (file {i+1}/{total_files})",
-                    message=f"Converting {filename} to H.265 ({i+1}/{total_files})"
+                    message=f"Converting {filename} to H.265 ({i+1}/{total_files})",
                 )
             logger.info(f"Converting {video} to H.265")
 
@@ -873,58 +991,78 @@ class YTToJellyfin:
                     cmd,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.STDOUT,
-                    universal_newlines=True
+                    universal_newlines=True,
                 )
+                if job:
+                    job.process = process
 
                 for line in process.stdout:
+                    if job and job.status == "cancelled":
+                        process.terminate()
+                        break
                     # Log ffmpeg output for debugging
                     logger.debug(line.strip())
 
                     if job and "time=" in line:
                         # Extract progress from ffmpeg output
                         try:
-                            time_str = re.search(r'time=(\d+:\d+:\d+\.\d+)', line)
+                            time_str = re.search(r"time=(\d+:\d+:\d+\.\d+)", line)
                             if time_str:
-                                time_parts = time_str.group(1).split(':')
+                                time_parts = time_str.group(1).split(":")
                                 seconds = (
-                                    float(time_parts[0]) * 3600 +
-                                    float(time_parts[1]) * 60 +
-                                    float(time_parts[2])
+                                    float(time_parts[0]) * 3600
+                                    + float(time_parts[1]) * 60
+                                    + float(time_parts[2])
                                 )
 
                                 # Get duration of video
                                 duration_cmd = [
-                                    'ffprobe', '-v', 'error', '-show_entries', 'format=duration',
-                                    '-of', 'default=noprint_wrappers=1:nokey=1', str(video)
+                                    "ffprobe",
+                                    "-v",
+                                    "error",
+                                    "-show_entries",
+                                    "format=duration",
+                                    "-of",
+                                    "default=noprint_wrappers=1:nokey=1",
+                                    str(video),
                                 ]
                                 duration_result = subprocess.run(
-                                    duration_cmd, capture_output=True, text=True, check=True
+                                    duration_cmd,
+                                    capture_output=True,
+                                    text=True,
+                                    check=True,
                                 )
                                 duration = float(duration_result.stdout.strip())
 
                                 if duration > 0:
-                                    file_progress = min(100, int(seconds / duration * 100))
+                                    file_progress = min(
+                                        100, int(seconds / duration * 100)
+                                    )
                                     # Overall progress is a combination of completed files and current file progress
                                     total_progress = min(
                                         99,
-                                        ((i) / total_files * 100) +
-                                        (file_progress / total_files)
+                                        ((i) / total_files * 100)
+                                        + (file_progress / total_files),
                                     )
 
                                     # Update job with both file and overall progress
                                     job.update(
                                         progress=total_progress,
                                         stage_progress=file_progress,
-                                        detailed_status=f"Converting {filename}: {file_progress}% (file {i+1}/{total_files})"
+                                        detailed_status=f"Converting {filename}: {file_progress}% (file {i+1}/{total_files})",
                                     )
 
                                     # Add progress updates less frequently to avoid flooding the log
                                     if file_progress % 20 == 0:
-                                        job.update(message=f"Converting {filename}: {file_progress}% complete")
+                                        job.update(
+                                            message=f"Converting {filename}: {file_progress}% complete"
+                                        )
                         except Exception as e:
                             logger.error(f"Error parsing progress: {e}")
 
                 process.wait()
+                if job:
+                    job.process = None
 
                 if process.returncode == 0:
                     os.rename(temp_file, f"{base}.mp4")
@@ -934,14 +1072,16 @@ class YTToJellyfin:
                     if job:
                         job.update(
                             message=f"Successfully converted {filename} to H.265",
-                            detailed_status=f"Converted {i+1}/{total_files} files"
+                            detailed_status=f"Converted {i+1}/{total_files} files",
                         )
                 else:
-                    logger.error(f"Failed to convert {video}, return code: {process.returncode}")
+                    logger.error(
+                        f"Failed to convert {video}, return code: {process.returncode}"
+                    )
                     if job:
                         job.update(
                             message=f"Failed to convert {filename}, return code: {process.returncode}",
-                            detailed_status=f"Error converting {filename}"
+                            detailed_status=f"Error converting {filename}",
                         )
                     if os.path.exists(temp_file):
                         os.remove(temp_file)
@@ -949,9 +1089,10 @@ class YTToJellyfin:
             except subprocess.SubprocessError as e:
                 logger.error(f"Failed to convert {video}: {e}")
                 if job:
+                    job.process = None
                     job.update(
                         message=f"Failed to convert {filename}: {str(e)}",
-                        detailed_status=f"Error converting {filename}"
+                        detailed_status=f"Error converting {filename}",
                     )
                 if os.path.exists(temp_file):
                     os.remove(temp_file)
@@ -961,53 +1102,77 @@ class YTToJellyfin:
                 progress=100,
                 stage_progress=100,
                 detailed_status="Video conversion completed",
-                message="Video conversion completed"
+                message="Video conversion completed",
             )
 
-    def generate_artwork(self, folder: str, show_name: str, season_num: str, job_id: str) -> None:
+    def generate_artwork(
+        self, folder: str, show_name: str, season_num: str, job_id: str
+    ) -> None:
         """Generate thumbnails, TV show and season artwork."""
         job = self.jobs.get(job_id)
         if job:
-            job.update(status="generating_artwork", message="Generating thumbnails and artwork")
+            job.update(
+                status="generating_artwork", message="Generating thumbnails and artwork"
+            )
 
         show_folder = str(Path(folder).parent)
 
         # Generate episode thumbnails
-        videos = list(Path(folder).glob(f'*S{season_num}E*.mp4'))
+        videos = list(Path(folder).glob(f"*S{season_num}E*.mp4"))
         for i, video in enumerate(videos):
             # Get the video file path without extension
-            video_base = str(video).rsplit('.', 1)[0]
+            video_base = str(video).rsplit(".", 1)[0]
 
             # Get the basename without path
             basename = os.path.basename(video_base)
 
             # Check if filename cleaning is enabled
-            if self.config.get('clean_filenames', True):
+            if self.config.get("clean_filenames", True):
                 # Clean the filename (replace underscores with spaces)
                 basename = self.clean_filename(basename)
 
             # Create thumb path with the potentially cleaned filename
-            thumb_path = os.path.join(os.path.dirname(video_base), f"{basename}-thumb.jpg")
+            thumb_path = os.path.join(
+                os.path.dirname(video_base), f"{basename}-thumb.jpg"
+            )
 
             try:
-                subprocess.run([
-                    'ffmpeg', '-ss', '00:01:30', '-i', str(video),
-                    '-vframes', '1', '-q:v', '2', thumb_path
-                ], check=True, capture_output=True)
+                subprocess.run(
+                    [
+                        "ffmpeg",
+                        "-ss",
+                        "00:01:30",
+                        "-i",
+                        str(video),
+                        "-vframes",
+                        "1",
+                        "-q:v",
+                        "2",
+                        thumb_path,
+                    ],
+                    check=True,
+                    capture_output=True,
+                )
                 logger.info(f"Generated thumbnail: {thumb_path}")
 
                 if job and videos:
-                    progress = int((i + 1) / len(videos) * 30)  # Thumbnails are 30% of artwork work
-                    job.update(progress=progress, message=f"Generated thumbnail for {basename}")
+                    progress = int(
+                        (i + 1) / len(videos) * 30
+                    )  # Thumbnails are 30% of artwork work
+                    job.update(
+                        progress=progress, message=f"Generated thumbnail for {basename}"
+                    )
 
             except subprocess.CalledProcessError:
                 logger.error(f"Failed to generate thumbnail for {video}")
                 if job:
-                    job.update(message=f"Failed to generate thumbnail for {os.path.basename(str(video))}")
+                    job.update(
+                        message=f"Failed to generate thumbnail for {os.path.basename(str(video))}"
+                    )
 
         # Create TV show artwork
         try:
-            episodes = list(Path(folder).glob(f'*S{season_num}E*.mp4'))
+            episodes = list(Path(folder).glob(f"*S{season_num}E*.mp4"))
             if not episodes:
                 logger.warning("No episodes found for artwork generation")
                 if job:
@@ -1021,22 +1186,50 @@ class YTToJellyfin:
             temp_posters = []
             for i, episode in enumerate(episodes[:1]):
                 poster_file = os.path.join(self.temp_dir, f"tmp_poster_{i:03d}.jpg")
-                subprocess.run([
-                    'ffmpeg', '-i', str(episode),
-                    '-vf', "select='not(mod(n,1000))',scale=640:360",
-                    '-vframes', '3', poster_file
-                ], check=True, capture_output=True)
+                subprocess.run(
+                    [
+                        "ffmpeg",
+                        "-i",
+                        str(episode),
+                        "-vf",
+                        "select='not(mod(n,1000))',scale=640:360",
+                        "-vframes",
+                        "3",
+                        poster_file,
+                    ],
+                    check=True,
+                    capture_output=True,
+                )
                 temp_posters.append(poster_file)
 
             # Create show poster
             if temp_posters:
                 poster_path = os.path.join(show_folder, "poster.jpg")
-                subprocess.run([
-                    'convert', *temp_posters, '-gravity', 'Center', '-background', 'Black',
-                    '-resize', '1000x1500^', '-extent', '1000x1500',
-                    '-pointsize', '80', '-fill', 'white', '-gravity', 'south',
-                    '-annotate', '+0+50', show_name, poster_path
-                ], check=True)
+                subprocess.run(
+                    [
+                        "convert",
+                        *temp_posters,
+                        "-gravity",
+                        "Center",
+                        "-background",
+                        "Black",
+                        "-resize",
+                        "1000x1500^",
+                        "-extent",
+                        "1000x1500",
+                        "-pointsize",
+                        "80",
+                        "-fill",
+                        "white",
+                        "-gravity",
+                        "south",
+                        "-annotate",
+                        "+0+50",
+                        show_name,
+                        poster_path,
+                    ],
+                    check=True,
+                )
 
                 if job:
                     job.update(progress=60, message="Created show poster")
@@ -1047,24 +1240,56 @@ class YTToJellyfin:
 
             for i, episode in enumerate(episodes[:6]):
                 frame_file = os.path.join(season_frames_dir, f"frame_{i:03d}.jpg")
-                subprocess.run([
-                    'ffmpeg', '-i', str(episode), '-vf', 'thumbnail',
-                    '-frames:v', '1', frame_file
-                ], check=True, capture_output=True)
+                subprocess.run(
+                    [
+                        "ffmpeg",
+                        "-i",
+                        str(episode),
+                        "-vf",
+                        "thumbnail",
+                        "-frames:v",
+                        "1",
+                        frame_file,
+                    ],
+                    check=True,
+                    capture_output=True,
+                )
 
             # Create season poster and landscape version
-            season_frames = list(Path(season_frames_dir).glob('*.jpg'))
+            season_frames = list(Path(season_frames_dir).glob("*.jpg"))
             if season_frames:
                 montage_args = [
-                    'montage', '-geometry', '400x225+5+5', '-background', 'black',
-                    '-tile', '3x2', *[str(f) for f in season_frames], '-'
+                    "montage",
+                    "-geometry",
+                    "400x225+5+5",
+                    "-background",
+                    "black",
+                    "-tile",
+                    "3x2",
+                    *[str(f) for f in season_frames],
+                    "-",
                 ]
 
                 convert_args = [
-                    'convert', '-', '-resize', '1000x1500', '-',
-                    '-gravity', 'south', '-background', '#00000080', '-splice', '0x60',
-                    '-pointsize', '48', '-fill', 'white', '-annotate', '+0+20',
-                    f"Season {season_num}", f"{folder}/season{season_num}-poster.jpg"
+                    "convert",
+                    "-",
+                    "-resize",
+                    "1000x1500",
+                    "-",
+                    "-gravity",
+                    "south",
+                    "-background",
+                    "#00000080",
+                    "-splice",
+                    "0x60",
+                    "-pointsize",
+                    "48",
+                    "-fill",
+                    "white",
+                    "-annotate",
+                    "+0+20",
+                    f"Season {season_num}",
+                    f"{folder}/season{season_num}-poster.jpg",
                 ]
 
                 p1 = subprocess.Popen(montage_args, stdout=subprocess.PIPE)
@@ -1072,10 +1297,16 @@ class YTToJellyfin:
                 p2.communicate()
 
                 # Create landscape version
-                subprocess.run([
-                    'convert', f"{folder}/season{season_num}-poster.jpg",
-                    '-resize', '1000x562!', f"{folder}/season{season_num}.jpg"
-                ], check=True)
+                subprocess.run(
+                    [
+                        "convert",
+                        f"{folder}/season{season_num}-poster.jpg",
+                        "-resize",
+                        "1000x562!",
+                        f"{folder}/season{season_num}.jpg",
+                    ],
+                    check=True,
+                )
 
                 if job:
                     job.update(progress=100, message="Created season artwork")
@@ -1085,7 +1316,9 @@ class YTToJellyfin:
             if job:
                 job.update(message=f"Error generating artwork: {str(e)}")
 
-    def create_nfo_files(self, folder: str, show_name: str, season_num: str, job_id: str) -> None:
+    def create_nfo_files(
+        self, folder: str, show_name: str, season_num: str, job_id: str
+    ) -> None:
         """Create NFO files for TV show and season."""
         job = self.jobs.get(job_id)
         if job:
@@ -1101,7 +1334,7 @@ class YTToJellyfin:
   <plot>Season {season_num} of {show_name}</plot>
 </season>
 """
-        with open(f"{folder}/season.nfo", 'w') as f:
+        with open(f"{folder}/season.nfo", "w") as f:
             f.write(season_nfo)
 
         # TV Show NFO
@@ -1111,7 +1344,7 @@ class YTToJellyfin:
   <studio>YouTube</studio>
 </tvshow>
 """
-        with open(f"{show_folder}/tvshow.nfo", 'w') as f:
+        with open(f"{show_folder}/tvshow.nfo", "w") as f:
             f.write(tvshow_nfo)
 
         if job:
@@ -1119,11 +1352,11 @@ class YTToJellyfin:
 
     def copy_to_jellyfin(self, show_name: str, season_num: str, job_id: str) -> None:
         """Copy processed media files to Jellyfin TV folder."""
-        if not self.config.get('jellyfin_enabled', False):
+        if not self.config.get("jellyfin_enabled", False):
             logger.info("Jellyfin integration disabled, skipping file copy")
             return
 
-        jellyfin_tv_path = self.config.get('jellyfin_tv_path', '')
+        jellyfin_tv_path = self.config.get("jellyfin_tv_path", "")
         if not jellyfin_tv_path:
             logger.error("Jellyfin TV path not configured, skipping file copy")
             return
@@ -1135,14 +1368,16 @@ class YTToJellyfin:
                 stage="copying_to_jellyfin",
                 progress=95,
                 detailed_status="Copying files to Jellyfin TV folder",
-                message="Starting copy to Jellyfin TV folder"
+                message="Starting copy to Jellyfin TV folder",
             )
 
         # Sanitize show name for folder path
         sanitized_show = self.sanitize_name(show_name)
 
         # Source folder in our media directory
-        source_folder = Path(self.config['output_dir']) / sanitized_show / f"Season {season_num}"
+        source_folder = (
+            Path(self.config["output_dir"]) / sanitized_show / f"Season {season_num}"
+        )
 
         # Destination folder in Jellyfin TV directory
         dest_show_folder = Path(jellyfin_tv_path) / sanitized_show
@@ -1157,7 +1392,9 @@ class YTToJellyfin:
             except OSError as e:
                 logger.error(f"Failed to create Jellyfin show folder: {e}")
                 if job:
-                    job.update(message=f"Error: Failed to create Jellyfin show folder: {e}")
+                    job.update(
+                        message=f"Error: Failed to create Jellyfin show folder: {e}"
+                    )
                 return
 
         if not os.path.exists(dest_season_folder):
@@ -1169,7 +1406,9 @@ class YTToJellyfin:
             except OSError as e:
                 logger.error(f"Failed to create Jellyfin season folder: {e}")
                 if job:
-                    job.update(message=f"Error: Failed to create Jellyfin season folder: {e}")
+                    job.update(
+                        message=f"Error: Failed to create Jellyfin season folder: {e}"
+                    )
                 return
 
         # Copy all media and metadata files
@@ -1185,7 +1424,7 @@ class YTToJellyfin:
                 job.update(
                     total_files=total_files,
                     processed_files=0,
-                    detailed_status=f"Copying {total_files} files to Jellyfin"
+                    detailed_status=f"Copying {total_files} files to Jellyfin",
                 )
 
             # Copy each file
@@ -1193,12 +1432,16 @@ class YTToJellyfin:
                 dest_file = dest_season_folder / file_path.name
 
                 # Skip if file already exists and is identical size
-                if os.path.exists(dest_file) and os.path.getsize(dest_file) == os.path.getsize(file_path):
-                    logger.info(f"Skipping {file_path.name} - already exists and same size")
+                if os.path.exists(dest_file) and os.path.getsize(
+                    dest_file
+                ) == os.path.getsize(file_path):
+                    logger.info(
+                        f"Skipping {file_path.name} - already exists and same size"
+                    )
                     if job:
                         job.update(
-                            processed_files=i+1,
-                            message=f"Skipped {file_path.name} - already exists"
+                            processed_files=i + 1,
+                            message=f"Skipped {file_path.name} - already exists",
                         )
                     continue
 
@@ -1208,18 +1451,27 @@ class YTToJellyfin:
 
                 if job:
                     job.update(
-                        processed_files=i+1,
+                        processed_files=i + 1,
                         file_name=file_path.name,
-                        stage_progress=int((i+1)/total_files*100),
+                        stage_progress=int((i + 1) / total_files * 100),
                         detailed_status=f"Copying: {file_path.name} ({i+1}/{total_files})",
-                        message=f"Copied {file_path.name} to Jellyfin TV folder"
+                        message=f"Copied {file_path.name} to Jellyfin TV folder",
                     )
 
             # Also copy show-level files (tvshow.nfo, poster.jpg, fanart.jpg)
             show_files = [
-                (Path(self.config['output_dir']) / sanitized_show / "tvshow.nfo", dest_show_folder / "tvshow.nfo"),
-                (Path(self.config['output_dir']) / sanitized_show / "poster.jpg", dest_show_folder / "poster.jpg"),
-                (Path(self.config['output_dir']) / sanitized_show / "fanart.jpg", dest_show_folder / "fanart.jpg")
+                (
+                    Path(self.config["output_dir"]) / sanitized_show / "tvshow.nfo",
+                    dest_show_folder / "tvshow.nfo",
+                ),
+                (
+                    Path(self.config["output_dir"]) / sanitized_show / "poster.jpg",
+                    dest_show_folder / "poster.jpg",
+                ),
+                (
+                    Path(self.config["output_dir"]) / sanitized_show / "fanart.jpg",
+                    dest_show_folder / "fanart.jpg",
+                ),
             ]
 
             for source, dest in show_files:
@@ -1234,11 +1486,11 @@ class YTToJellyfin:
                     progress=98,
                     stage_progress=100,
                     detailed_status="Copy to Jellyfin completed",
-                    message="Successfully copied all files to Jellyfin TV folder"
+                    message="Successfully copied all files to Jellyfin TV folder",
                 )
 
             # Trigger Jellyfin library scan (if API key provided)
-            if self.config.get('jellyfin_api_key') and self.config.get('jellyfin_host'):
+            if self.config.get("jellyfin_api_key") and self.config.get("jellyfin_host"):
                 self.trigger_jellyfin_scan(job_id)
 
         except (IOError, shutil.Error) as e:
@@ -1252,12 +1504,12 @@ class YTToJellyfin:
         if job:
             job.update(
                 detailed_status="Triggering Jellyfin library scan",
-                message="Triggering Jellyfin library scan"
+                message="Triggering Jellyfin library scan",
             )
 
-        api_key = self.config.get('jellyfin_api_key', '')
-        host = self.config.get('jellyfin_host', '')
-        port = self.config.get('jellyfin_port', '8096')
+        api_key = self.config.get("jellyfin_api_key", "")
+        host = self.config.get("jellyfin_host", "")
+        port = self.config.get("jellyfin_port", "8096")
 
         if not api_key or not host:
             logger.warning("Jellyfin API key or host not set, skipping library scan")
@@ -1267,6 +1519,7 @@ class YTToJellyfin:
 
         try:
             import requests
+
             response = requests.post(url, timeout=10)
 
             if response.status_code in (200, 204):
@@ -1274,9 +1527,13 @@ class YTToJellyfin:
                 if job:
                     job.update(message="Successfully triggered Jellyfin library scan")
             else:
-                logger.warning(f"Failed to trigger Jellyfin scan: {response.status_code} {response.text}")
+                logger.warning(
+                    f"Failed to trigger Jellyfin scan: {response.status_code} {response.text}"
+                )
                 if job:
-                    job.update(message=f"Failed to trigger Jellyfin scan: HTTP {response.status_code}")
+                    job.update(
+                        message=f"Failed to trigger Jellyfin scan: HTTP {response.status_code}"
+                    )
 
         except Exception as e:
             logger.error(f"Error triggering Jellyfin scan: {e}")
@@ -1311,30 +1568,59 @@ class YTToJellyfin:
             job.update(message=f"Created folder structure: {folder}")
 
             if job.playlist_start is not None:
-                dl_success = self.download_playlist(job.playlist_url, folder, job.season_num, job_id, job.playlist_start)
+                dl_success = self.download_playlist(
+                    job.playlist_url, folder, job.season_num, job_id, job.playlist_start
+                )
             else:
-                dl_success = self.download_playlist(job.playlist_url, folder, job.season_num, job_id)
+                dl_success = self.download_playlist(
+                    job.playlist_url, folder, job.season_num, job_id
+                )
+            if job.status == "cancelled":
+                return
             if not dl_success:
                 job.update(status="failed", message="Download failed")
                 return
 
-            self.process_metadata(folder, job.show_name, job.season_num, episode_start, job_id)
+            self.process_metadata(
+                folder, job.show_name, job.season_num, episode_start, job_id
+            )
+            if job.status == "cancelled":
+                return
             self.convert_video_files(folder, job.season_num, job_id)
+            if job.status == "cancelled":
+                return
             self.generate_artwork(folder, job.show_name, job.season_num, job_id)
+            if job.status == "cancelled":
+                return
             self.create_nfo_files(folder, job.show_name, job.season_num, job_id)
+            if job.status == "cancelled":
+                return
 
             # Copy to Jellyfin if enabled
-            if self.config.get('jellyfin_enabled', False) and self.config.get('jellyfin_tv_path'):
+            if self.config.get("jellyfin_enabled", False) and self.config.get(
+                "jellyfin_tv_path"
+            ):
                 self.copy_to_jellyfin(job.show_name, job.season_num, job_id)
 
-            job.update(status="completed", progress=100, message="Job completed successfully")
+            job.update(
+                status="completed", progress=100, message="Job completed successfully"
+            )
             logger.info(f"Job {job_id} completed successfully")
 
         except Exception as e:
             logger.exception(f"Error processing job {job_id}: {e}")
             job.update(status="failed", message=f"Error: {str(e)}")
 
-    def create_job(self, playlist_url: str, show_name: str, season_num: str, episode_start: str, playlist_start: Optional[int] = None, *, start_thread: bool = True) -> str:
+    def create_job(
+        self,
+        playlist_url: str,
+        show_name: str,
+        season_num: str,
+        episode_start: str,
+        playlist_start: Optional[int] = None,
+        *,
+        start_thread: bool = True,
+    ) -> str:
         """Create a new download job and return the job ID.
 
         Parameters
@@ -1344,7 +1630,9 @@ class YTToJellyfin:
             False to avoid running jobs concurrently.
         """
         job_id = str(uuid.uuid4())
-        job = DownloadJob(job_id, playlist_url, show_name, season_num, episode_start, playlist_start)
+        job = DownloadJob(
+            job_id, playlist_url, show_name, season_num, episode_start, playlist_start
+        )
 
         # Preload queue of files based on playlist info
         try:
@@ -1354,7 +1642,7 @@ class YTToJellyfin:
         try:
             videos = self.get_playlist_videos(playlist_url)
             start_idx = playlist_start or 1
-            for i, entry in enumerate(videos[start_idx-1:], start=ep_start_num):
+            for i, entry in enumerate(videos[start_idx - 1 :], start=ep_start_num):
                 job.remaining_files.append(
                     f"{entry.get('title', 'Video')} S{season_num}E{str(i).zfill(2)}"
                 )
@@ -1369,11 +1657,14 @@ class YTToJellyfin:
             self.jobs[job_id] = job
 
             # Limit the number of completed jobs
-            completed_jobs = [j for j in self.jobs.values()
-                             if j.status == "completed" or j.status == "failed"]
+            completed_jobs = [
+                j
+                for j in self.jobs.values()
+                if j.status == "completed" or j.status == "failed"
+            ]
             completed_jobs.sort(key=lambda j: j.updated_at)
 
-            while len(completed_jobs) > self.config.get('completed_jobs_limit', 10):
+            while len(completed_jobs) > self.config.get("completed_jobs_limit", 10):
                 old_job = completed_jobs.pop(0)
                 del self.jobs[old_job.job_id]
 
@@ -1394,10 +1685,30 @@ class YTToJellyfin:
         with self.job_lock:
             return [job.to_dict(include_messages=False) for job in self.jobs.values()]
 
+    def cancel_job(self, job_id: str) -> bool:
+        """Cancel a running job by terminating its process."""
+        job = self.jobs.get(job_id)
+        if not job or job.status in {"completed", "failed", "cancelled"}:
+            return False
+
+        process = getattr(job, "process", None)
+        if process and process.poll() is None:
+            try:
+                process.terminate()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+            except Exception as e:  # pragma: no cover - termination errors
+                logger.error(f"Failed to terminate process for job {job_id}: {e}")
+        job.process = None
+        job.update(status="cancelled", message="Job cancelled")
+        return True
+
     def list_media(self) -> List[Dict]:
         """List all media in the output directory."""
         media = []
-        output_dir = Path(self.config['output_dir'])
+        output_dir = Path(self.config["output_dir"])
 
         if not output_dir.exists():
             return media
@@ -1406,11 +1717,7 @@ class YTToJellyfin:
             if not show_dir.is_dir():
                 continue
 
-            show = {
-                "name": show_dir.name,
-                "path": str(show_dir),
-                "seasons": []
-            }
+            show = {"name": show_dir.name, "path": str(show_dir), "seasons": []}
 
             # Get seasons
             for season_dir in show_dir.iterdir():
@@ -1420,7 +1727,7 @@ class YTToJellyfin:
                 season = {
                     "name": season_dir.name,
                     "path": str(season_dir),
-                    "episodes": []
+                    "episodes": [],
                 }
 
                 # Get episodes
@@ -1432,7 +1739,9 @@ class YTToJellyfin:
                         "name": episode_file.stem,
                         "path": str(episode_file),
                         "size": episode_file.stat().st_size,
-                        "modified": datetime.fromtimestamp(episode_file.stat().st_mtime).strftime("%Y-%m-%d %H:%M:%S"),
+                        "modified": datetime.fromtimestamp(
+                            episode_file.stat().st_mtime
+                        ).strftime("%Y-%m-%d %H:%M:%S"),
                         "episode_num": episode_num,
                     }
                     season["episodes"].append(episode)
@@ -1453,23 +1762,29 @@ class YTToJellyfin:
         """Return information about registered playlists."""
         playlists = []
         for pid, info in self.playlists.items():
-            archive = info.get('archive', self._get_archive_file(info['url']))
+            archive = info.get("archive", self._get_archive_file(info["url"]))
             last_downloaded = 0
             if os.path.exists(archive):
-                with open(archive, 'r') as f:
+                with open(archive, "r") as f:
                     last_downloaded = sum(1 for _ in f)
 
-            folder = Path(self.config['output_dir']) / self.sanitize_name(info['show_name']) / f"Season {info['season_num']}"
-            last_episode = self._get_existing_max_index(str(folder), info['season_num'])
+            folder = (
+                Path(self.config["output_dir"])
+                / self.sanitize_name(info["show_name"])
+                / f"Season {info['season_num']}"
+            )
+            last_episode = self._get_existing_max_index(str(folder), info["season_num"])
 
-            playlists.append({
-                'id': pid,
-                'url': info['url'],
-                'show_name': info['show_name'],
-                'season_num': info['season_num'],
-                'last_episode': last_episode,
-                'downloaded_videos': last_downloaded
-            })
+            playlists.append(
+                {
+                    "id": pid,
+                    "url": info["url"],
+                    "show_name": info["show_name"],
+                    "season_num": info["season_num"],
+                    "last_episode": last_episode,
+                    "downloaded_videos": last_downloaded,
+                }
+            )
 
         return playlists
 
@@ -1477,26 +1792,37 @@ class YTToJellyfin:
         """Return list of videos in a playlist using yt-dlp."""
         try:
             result = subprocess.run(
-                [self.config['ytdlp_path'], '--flat-playlist', '--dump-single-json', url],
+                [
+                    self.config["ytdlp_path"],
+                    "--flat-playlist",
+                    "--dump-single-json",
+                    url,
+                ],
                 capture_output=True,
                 text=True,
                 check=True,
             )
             data = json.loads(result.stdout)
-            entries = data.get('entries', [])
+            entries = data.get("entries", [])
             videos = []
             for idx, entry in enumerate(entries, start=1):
-                videos.append({'index': idx, 'id': entry.get('id'), 'title': entry.get('title')})
+                videos.append(
+                    {"index": idx, "id": entry.get("id"), "title": entry.get("title")}
+                )
             return videos
         except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
             logger.error(f"Failed to fetch playlist info: {e}")
             return []
 
-    def process(self, playlist_url: str, show_name: str, season_num: str, episode_start: int) -> bool:
+    def process(
+        self, playlist_url: str, show_name: str, season_num: str, episode_start: int
+    ) -> bool:
         """Process the entire workflow from download to final media preparation."""
         try:
             # Create a job to track progress
-            job_id = self.create_job(playlist_url, show_name, season_num, str(episode_start))
+            job_id = self.create_job(
+                playlist_url, show_name, season_num, str(episode_start)
+            )
 
             # Wait for job to complete
             job = self.jobs.get(job_id)
@@ -1514,36 +1840,40 @@ class YTToJellyfin:
 
 
 # Create Flask application for web interface
-app = Flask(__name__,
-            template_folder=os.path.join(os.path.dirname(__file__), 'web/templates'),
-            static_folder=os.path.join(os.path.dirname(__file__), 'web/static'))
+app = Flask(
+    __name__,
+    template_folder=os.path.join(os.path.dirname(__file__), "web/templates"),
+    static_folder=os.path.join(os.path.dirname(__file__), "web/static"),
+)
 
 ytj = YTToJellyfin()
 
-@app.route('/')
+
+@app.route("/")
 def index():
     """Main web interface page."""
-    return render_template('index.html',
-                          jobs=ytj.get_jobs(),
-                          media=ytj.list_media())
+    return render_template("index.html", jobs=ytj.get_jobs(), media=ytj.list_media())
 
-@app.route('/jobs', methods=['GET', 'POST'])
+
+@app.route("/jobs", methods=["GET", "POST"])
 def jobs():
     """Handle job listing and creation."""
-    if request.method == 'POST':
+    if request.method == "POST":
         # Create new job
-        playlist_url = request.form.get('playlist_url')
-        show_name = request.form.get('show_name')
-        season_num = request.form.get('season_num')
-        episode_start = request.form.get('episode_start')
-        playlist_start = request.form.get('playlist_start')
+        playlist_url = request.form.get("playlist_url")
+        show_name = request.form.get("show_name")
+        season_num = request.form.get("season_num")
+        episode_start = request.form.get("episode_start")
+        playlist_start = request.form.get("playlist_start")
 
         if not playlist_url or not show_name or not season_num or not episode_start:
             return jsonify({"error": "Missing required parameters"}), 400
 
         playlist_start_int = int(playlist_start) if playlist_start else None
         if playlist_start_int is not None:
-            job_id = ytj.create_job(playlist_url, show_name, season_num, episode_start, playlist_start_int)
+            job_id = ytj.create_job(
+                playlist_url, show_name, season_num, episode_start, playlist_start_int
+            )
         else:
             job_id = ytj.create_job(playlist_url, show_name, season_num, episode_start)
         return jsonify({"job_id": job_id})
@@ -1551,85 +1881,118 @@ def jobs():
         # Get all jobs
         return jsonify(ytj.get_jobs())
 
-@app.route('/jobs/<job_id>', methods=['GET'])
+
+@app.route("/jobs/<job_id>", methods=["GET", "DELETE"])
 def job_detail(job_id):
-    """Get information about a specific job."""
+    """Get or modify a specific job."""
+    if request.method == "DELETE":
+        if ytj.cancel_job(job_id):
+            return jsonify({"success": True})
+        return jsonify({"error": "Job not found"}), 404
+
     job = ytj.get_job(job_id)
     if job:
         return jsonify(job)
     return jsonify({"error": "Job not found"}), 404
 
-@app.route('/media', methods=['GET'])
+
+@app.route("/media", methods=["GET"])
 def media():
     """List all media files."""
     return jsonify(ytj.list_media())
 
-@app.route('/playlists', methods=['GET'])
+
+@app.route("/playlists", methods=["GET"])
 def playlists():
     """Return registered playlists."""
     return jsonify(ytj.list_playlists())
 
-@app.route('/playlist_info')
+
+@app.route("/playlist_info")
 def playlist_info():
-    url = request.args.get('url')
+    url = request.args.get("url")
     if not url:
-        return jsonify({'error': 'Missing url'}), 400
+        return jsonify({"error": "Missing url"}), 400
     return jsonify(ytj.get_playlist_videos(url))
 
-@app.route('/playlists/check', methods=['POST'])
+
+@app.route("/playlists/check", methods=["POST"])
 def playlists_check():
     """Check all playlists for updates and return created job ids."""
     jobs = ytj.check_playlist_updates()
-    return jsonify({'created_jobs': jobs})
+    return jsonify({"created_jobs": jobs})
 
-@app.route('/config', methods=['GET', 'PUT'])
+
+@app.route("/config", methods=["GET", "PUT"])
 def config():
     """Get or update configuration."""
-    if request.method == 'PUT':
+    if request.method == "PUT":
         # Get updated configuration from request
         new_config = request.json
         if new_config:
             # Update allowed configuration settings
             allowed_keys = [
-                'output_dir', 'quality', 'use_h265', 'crf', 'web_port',
-                'completed_jobs_limit', 'jellyfin_enabled', 'jellyfin_tv_path',
-                'jellyfin_host', 'jellyfin_port', 'jellyfin_api_key', 'clean_filenames',
-                'update_checker_enabled', 'update_checker_interval'
+                "output_dir",
+                "quality",
+                "use_h265",
+                "crf",
+                "web_port",
+                "completed_jobs_limit",
+                "jellyfin_enabled",
+                "jellyfin_tv_path",
+                "jellyfin_host",
+                "jellyfin_port",
+                "jellyfin_api_key",
+                "clean_filenames",
+                "update_checker_enabled",
+                "update_checker_interval",
             ]
 
             should_restart_update = False
             # Update only allowed keys
             for key in allowed_keys:
                 if key in new_config:
-                    if key in ['jellyfin_enabled', 'use_h265', 'clean_filenames', 'update_checker_enabled']:
+                    if key in [
+                        "jellyfin_enabled",
+                        "use_h265",
+                        "clean_filenames",
+                        "update_checker_enabled",
+                    ]:
                         ytj.config[key] = new_config[key] is True
-                    elif key in ['crf', 'web_port', 'completed_jobs_limit', 'update_checker_interval']:
+                    elif key in [
+                        "crf",
+                        "web_port",
+                        "completed_jobs_limit",
+                        "update_checker_interval",
+                    ]:
                         ytj.config[key] = int(new_config[key])
                     else:
                         ytj.config[key] = new_config[key]
 
-                    if key in ['update_checker_enabled', 'update_checker_interval']:
+                    if key in ["update_checker_enabled", "update_checker_interval"]:
                         should_restart_update = True
 
             # Special handling for cookies_path
-            if 'cookies_path' in new_config:
-                cookies_path = new_config['cookies_path']
+            if "cookies_path" in new_config:
+                cookies_path = new_config["cookies_path"]
                 # Store the path for display purposes
-                ytj.config['cookies_path'] = cookies_path
+                ytj.config["cookies_path"] = cookies_path
 
                 # Check if the file exists and update cookies if it does
                 if os.path.exists(cookies_path):
-                    ytj.config['cookies'] = cookies_path
+                    ytj.config["cookies"] = cookies_path
                     logger.info(f"Updated cookies file path to: {cookies_path}")
                 else:
                     # Clear cookies if path is invalid
-                    ytj.config['cookies'] = ''
-                    logger.warning(f"Cookies file not found at {cookies_path}, not using cookies")
+                    ytj.config["cookies"] = ""
+                    logger.warning(
+                        f"Cookies file not found at {cookies_path}, not using cookies"
+                    )
 
             if should_restart_update:
                 if ytj.update_thread and ytj.update_thread.is_alive():
                     ytj.update_thread = None
-                if ytj.config.get('update_checker_enabled'):
+                if ytj.config.get("update_checker_enabled"):
                     ytj.start_update_checker()
 
             return jsonify({"success": True, "message": "Configuration updated"})
@@ -1639,60 +2002,72 @@ def config():
         # Get configuration
         safe_config = {k: v for k, v in ytj.config.items()}
         # Add cookies path for rendering the UI
-        if 'cookies_path' not in safe_config and 'cookies' in safe_config:
-            safe_config['cookies_path'] = safe_config['cookies']
+        if "cookies_path" not in safe_config and "cookies" in safe_config:
+            safe_config["cookies_path"] = safe_config["cookies"]
 
         # For security, don't expose actual cookie file content or path
-        if 'cookies' in safe_config:
-            del safe_config['cookies']
+        if "cookies" in safe_config:
+            del safe_config["cookies"]
 
         return jsonify(safe_config)
 
+
 def main():
     """Parse command line arguments and execute the application."""
-    parser = argparse.ArgumentParser(description='Download YouTube playlists as TV show episodes for Jellyfin')
-    parser.add_argument('--web-only', action='store_true', help='Start only the web interface')
-    parser.add_argument('--url', help='YouTube playlist URL')
-    parser.add_argument('--show-name', help='TV show name')
-    parser.add_argument('--season-num', help='Season number (e.g., 01)')
-    parser.add_argument('--episode-start', help='Episode start number (e.g., 01)')
-    parser.add_argument('--output-dir', help='Output directory')
-    parser.add_argument('--quality', help='Video quality (720, 1080, etc.)')
-    parser.add_argument('--no-h265', action='store_true', help='Disable H.265 conversion')
-    parser.add_argument('--crf', type=int, help='CRF value for H.265 conversion')
-    parser.add_argument('--config', help='Path to config file')
-    parser.add_argument('--check-updates', action='store_true',
-                        help='Check registered playlists for new videos')
+    parser = argparse.ArgumentParser(
+        description="Download YouTube playlists as TV show episodes for Jellyfin"
+    )
+    parser.add_argument(
+        "--web-only", action="store_true", help="Start only the web interface"
+    )
+    parser.add_argument("--url", help="YouTube playlist URL")
+    parser.add_argument("--show-name", help="TV show name")
+    parser.add_argument("--season-num", help="Season number (e.g., 01)")
+    parser.add_argument("--episode-start", help="Episode start number (e.g., 01)")
+    parser.add_argument("--output-dir", help="Output directory")
+    parser.add_argument("--quality", help="Video quality (720, 1080, etc.)")
+    parser.add_argument(
+        "--no-h265", action="store_true", help="Disable H.265 conversion"
+    )
+    parser.add_argument("--crf", type=int, help="CRF value for H.265 conversion")
+    parser.add_argument("--config", help="Path to config file")
+    parser.add_argument(
+        "--check-updates",
+        action="store_true",
+        help="Check registered playlists for new videos",
+    )
 
     # Normal commandline usage still supported as before
-    parser.add_argument('url_pos', nargs='?', help='YouTube playlist URL (positional)')
-    parser.add_argument('show_name_pos', nargs='?', help='TV show name (positional)')
-    parser.add_argument('season_num_pos', nargs='?', help='Season number (positional)')
-    parser.add_argument('episode_start_pos', nargs='?', help='Episode start number (positional)')
+    parser.add_argument("url_pos", nargs="?", help="YouTube playlist URL (positional)")
+    parser.add_argument("show_name_pos", nargs="?", help="TV show name (positional)")
+    parser.add_argument("season_num_pos", nargs="?", help="Season number (positional)")
+    parser.add_argument(
+        "episode_start_pos", nargs="?", help="Episode start number (positional)"
+    )
 
     args = parser.parse_args()
 
     # Set environment variables from command line args if provided
     if args.output_dir:
-        os.environ['OUTPUT_DIR'] = args.output_dir
+        os.environ["OUTPUT_DIR"] = args.output_dir
     if args.quality:
-        os.environ['VIDEO_QUALITY'] = args.quality
+        os.environ["VIDEO_QUALITY"] = args.quality
     if args.no_h265:
-        os.environ['USE_H265'] = 'false'
+        os.environ["USE_H265"] = "false"
     if args.crf:
-        os.environ['CRF'] = str(args.crf)
+        os.environ["CRF"] = str(args.crf)
     if args.config:
-        os.environ['CONFIG_FILE'] = args.config
+        os.environ["CONFIG_FILE"] = args.config
 
     if args.check_updates:
         ytj.check_playlist_updates()
         return 0
 
     # Web-only mode
-    if args.web_only or ytj.config.get('web_enabled', True):
+    if args.web_only or ytj.config.get("web_enabled", True):
         # Start web interface
-        host = ytj.config.get('web_host', '0.0.0.0')
-        port = ytj.config.get('web_port', 8000)
+        host = ytj.config.get("web_host", "0.0.0.0")
+        port = ytj.config.get("web_port", 8000)
 
         if args.web_only:
             logger.info(f"Starting web interface on {host}:{port}")
@@ -1706,14 +2081,30 @@ def main():
     episode_start = args.episode_start or args.episode_start_pos
 
     # Use defaults from config if available
-    if not url and 'defaults' in ytj.config and 'playlist_url' in ytj.config['defaults']:
-        url = ytj.config['defaults']['playlist_url']
-    if not show_name and 'defaults' in ytj.config and 'show_name' in ytj.config['defaults']:
-        show_name = ytj.config['defaults']['show_name']
-    if not season_num and 'defaults' in ytj.config and 'season_num' in ytj.config['defaults']:
-        season_num = ytj.config['defaults']['season_num']
-    if not episode_start and 'defaults' in ytj.config and 'episode_start' in ytj.config['defaults']:
-        episode_start = ytj.config['defaults']['episode_start']
+    if (
+        not url
+        and "defaults" in ytj.config
+        and "playlist_url" in ytj.config["defaults"]
+    ):
+        url = ytj.config["defaults"]["playlist_url"]
+    if (
+        not show_name
+        and "defaults" in ytj.config
+        and "show_name" in ytj.config["defaults"]
+    ):
+        show_name = ytj.config["defaults"]["show_name"]
+    if (
+        not season_num
+        and "defaults" in ytj.config
+        and "season_num" in ytj.config["defaults"]
+    ):
+        season_num = ytj.config["defaults"]["season_num"]
+    if (
+        not episode_start
+        and "defaults" in ytj.config
+        and "episode_start" in ytj.config["defaults"]
+    ):
+        episode_start = ytj.config["defaults"]["episode_start"]
 
     if url and show_name and season_num and episode_start:
         try:
@@ -1725,23 +2116,24 @@ def main():
         success = ytj.process(url, show_name, season_num, episode_start_int)
 
         # Always start web interface after processing if enabled
-        if ytj.config.get('web_enabled', True) and not args.web_only:
-            host = ytj.config.get('web_host', '0.0.0.0')
-            port = ytj.config.get('web_port', 8000)
+        if ytj.config.get("web_enabled", True) and not args.web_only:
+            host = ytj.config.get("web_host", "0.0.0.0")
+            port = ytj.config.get("web_port", 8000)
             logger.info(f"Starting web interface on {host}:{port}")
             app.run(host=host, port=port, debug=False)
 
         return 0 if success else 1
-    elif ytj.config.get('web_enabled', True):
+    elif ytj.config.get("web_enabled", True):
         # No command-line parameters, but web is enabled
-        host = ytj.config.get('web_host', '0.0.0.0')
-        port = ytj.config.get('web_port', 8000)
+        host = ytj.config.get("web_host", "0.0.0.0")
+        port = ytj.config.get("web_port", 8000)
         logger.info(f"Starting web interface on {host}:{port}")
         app.run(host=host, port=port, debug=False)
         return 0
     else:
         parser.print_help()
         return 1
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,99 +6,118 @@ import tempfile
 from unittest.mock import patch, MagicMock
 
 # Add parent directory to path to import app.py
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from tubarr.web import app, ytj
 
+
 class TestAPIEndpoints(unittest.TestCase):
-    
+
     def setUp(self):
         # Configure app for testing
-        app.config['TESTING'] = True
+        app.config["TESTING"] = True
         self.client = app.test_client()
-        
+
         # Create sample jobs for testing
         ytj.jobs = {}
-    
+
     def tearDown(self):
         # Clean up after tests
         ytj.jobs = {}
-    
-    @patch('app.YTToJellyfin.create_job')
+
+    @patch("app.YTToJellyfin.create_job")
     def test_create_job(self, mock_create_job):
         """Test job creation endpoint"""
         # Mock the create_job method
         mock_create_job.return_value = "test-job-id"
-        
+
         # Test valid job creation
-        response = self.client.post('/jobs', data={
-            'playlist_url': 'https://youtube.com/playlist?list=TEST',
-            'show_name': 'Test Show',
-            'season_num': '01',
-            'episode_start': '01'
-        })
-        
+        response = self.client.post(
+            "/jobs",
+            data={
+                "playlist_url": "https://youtube.com/playlist?list=TEST",
+                "show_name": "Test Show",
+                "season_num": "01",
+                "episode_start": "01",
+            },
+        )
+
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data)
-        self.assertEqual(data['job_id'], "test-job-id")
-        
+        self.assertEqual(data["job_id"], "test-job-id")
+
         # Verify create_job was called with correct parameters
         mock_create_job.assert_called_once_with(
-            'https://youtube.com/playlist?list=TEST',
-            'Test Show',
-            '01',
-            '01'
+            "https://youtube.com/playlist?list=TEST", "Test Show", "01", "01"
         )
-        
+
         # Test missing parameters
-        response = self.client.post('/jobs', data={
-            'playlist_url': 'https://youtube.com/playlist?list=TEST'
-        })
-        
+        response = self.client.post(
+            "/jobs", data={"playlist_url": "https://youtube.com/playlist?list=TEST"}
+        )
+
         self.assertEqual(response.status_code, 400)
         data = json.loads(response.data)
-        self.assertIn('error', data)
-    
+        self.assertIn("error", data)
+
     def test_get_jobs(self):
         """Test getting list of jobs"""
         # Add test jobs
         ytj.jobs = {
-            'job1': MagicMock(to_dict=lambda **kwargs: {'job_id': 'job1', 'status': 'completed'}),
-            'job2': MagicMock(to_dict=lambda **kwargs: {'job_id': 'job2', 'status': 'in_progress'})
+            "job1": MagicMock(
+                to_dict=lambda **kwargs: {"job_id": "job1", "status": "completed"}
+            ),
+            "job2": MagicMock(
+                to_dict=lambda **kwargs: {"job_id": "job2", "status": "in_progress"}
+            ),
         }
-        
-        response = self.client.get('/jobs')
+
+        response = self.client.get("/jobs")
         self.assertEqual(response.status_code, 200)
-        
+
         data = json.loads(response.data)
         self.assertEqual(len(data), 2)
-        self.assertTrue(any(job['job_id'] == 'job1' for job in data))
-        self.assertTrue(any(job['job_id'] == 'job2' for job in data))
-    
+        self.assertTrue(any(job["job_id"] == "job1" for job in data))
+        self.assertTrue(any(job["job_id"] == "job2" for job in data))
+
     def test_get_job_detail(self):
         """Test getting details of a specific job"""
         # Add test job
         ytj.jobs = {
-            'job1': MagicMock(to_dict=lambda **kwargs: {
-                'job_id': 'job1',
-                'status': 'completed',
-                'show_name': 'Test Show'
-            })
+            "job1": MagicMock(
+                to_dict=lambda **kwargs: {
+                    "job_id": "job1",
+                    "status": "completed",
+                    "show_name": "Test Show",
+                }
+            )
         }
-        
+
         # Test valid job ID
-        response = self.client.get('/jobs/job1')
+        response = self.client.get("/jobs/job1")
         self.assertEqual(response.status_code, 200)
-        
+
         data = json.loads(response.data)
-        self.assertEqual(data['job_id'], 'job1')
-        self.assertEqual(data['show_name'], 'Test Show')
-        
+        self.assertEqual(data["job_id"], "job1")
+        self.assertEqual(data["show_name"], "Test Show")
+
         # Test invalid job ID
-        response = self.client.get('/jobs/nonexistent')
+        response = self.client.get("/jobs/nonexistent")
         self.assertEqual(response.status_code, 404)
-    
-    @patch('app.YTToJellyfin.list_media')
+
+    @patch("app.YTToJellyfin.cancel_job")
+    def test_cancel_job_endpoint(self, mock_cancel):
+        mock_cancel.return_value = True
+        response = self.client.delete("/jobs/job1")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(json.loads(response.data)["success"])
+        mock_cancel.assert_called_once_with("job1")
+
+        mock_cancel.return_value = False
+        response = self.client.delete("/jobs/missing")
+        self.assertEqual(response.status_code, 404)
+
+    @patch("app.YTToJellyfin.list_media")
     def test_get_media(self, mock_list_media):
         """Test media listing endpoint"""
         # Mock the list_media method
@@ -108,70 +127,76 @@ class TestAPIEndpoints(unittest.TestCase):
                 "seasons": [
                     {
                         "name": "Season 01",
-                        "episodes": [
-                            {"name": "Test Show S01E01", "size": 100000000}
-                        ]
+                        "episodes": [{"name": "Test Show S01E01", "size": 100000000}],
                     }
-                ]
+                ],
             }
         ]
-        
-        response = self.client.get('/media')
+
+        response = self.client.get("/media")
         self.assertEqual(response.status_code, 200)
-        
+
         data = json.loads(response.data)
         self.assertEqual(len(data), 1)
-        self.assertEqual(data[0]['name'], 'Test Show')
-        self.assertEqual(len(data[0]['seasons']), 1)
-        self.assertEqual(len(data[0]['seasons'][0]['episodes']), 1)
-    
+        self.assertEqual(data[0]["name"], "Test Show")
+        self.assertEqual(len(data[0]["seasons"]), 1)
+        self.assertEqual(len(data[0]["seasons"][0]["episodes"]), 1)
+
     def test_get_config(self):
         """Test configuration endpoint"""
         # Set some config values
         ytj.config = {
-            'output_dir': '/test/media',
-            'quality': '1080',
-            'use_h265': True,
-            'cookies': '/secret/path'  # This should be excluded from response
+            "output_dir": "/test/media",
+            "quality": "1080",
+            "use_h265": True,
+            "cookies": "/secret/path",  # This should be excluded from response
         }
-        
-        response = self.client.get('/config')
-        self.assertEqual(response.status_code, 200)
-        
-        data = json.loads(response.data)
-        self.assertEqual(data['output_dir'], '/test/media')
-        self.assertEqual(data['quality'], '1080')
-        self.assertTrue(data['use_h265'])
-        # Verify sensitive data is excluded
-        self.assertNotIn('cookies', data)
 
-    @patch('app.ytj.get_playlist_videos')
+        response = self.client.get("/config")
+        self.assertEqual(response.status_code, 200)
+
+        data = json.loads(response.data)
+        self.assertEqual(data["output_dir"], "/test/media")
+        self.assertEqual(data["quality"], "1080")
+        self.assertTrue(data["use_h265"])
+        # Verify sensitive data is excluded
+        self.assertNotIn("cookies", data)
+
+    @patch("app.ytj.get_playlist_videos")
     def test_playlist_info_endpoint(self, mock_get):
-        mock_get.return_value = [{'index':1,'id':'abc','title':'Video'}]
-        response = self.client.get('/playlist_info?url=https://playlist')
+        mock_get.return_value = [{"index": 1, "id": "abc", "title": "Video"}]
+        response = self.client.get("/playlist_info?url=https://playlist")
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data)
         self.assertEqual(len(data), 1)
-        mock_get.assert_called_once_with('https://playlist')
+        mock_get.assert_called_once_with("https://playlist")
 
-    @patch('app.ytj.check_playlist_updates')
+    @patch("app.ytj.check_playlist_updates")
     def test_playlists_check_endpoint(self, mock_check):
-        mock_check.return_value = ['job-1']
-        response = self.client.post('/playlists/check')
+        mock_check.return_value = ["job-1"]
+        response = self.client.post("/playlists/check")
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data)
-        self.assertEqual(data['created_jobs'], ['job-1'])
+        self.assertEqual(data["created_jobs"], ["job-1"])
         mock_check.assert_called_once()
 
-    @patch('os.path.exists', return_value=True)
+    @patch("os.path.exists", return_value=True)
     def test_config_put(self, mock_exists):
-        response = self.client.put('/config', json={'output_dir':'/new','cookies_path':'/cookies.txt','use_h265': False})
+        response = self.client.put(
+            "/config",
+            json={
+                "output_dir": "/new",
+                "cookies_path": "/cookies.txt",
+                "use_h265": False,
+            },
+        )
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data)
-        self.assertTrue(data['success'])
-        self.assertEqual(ytj.config['output_dir'], '/new')
-        self.assertFalse(ytj.config['use_h265'])
-        self.assertEqual(ytj.config['cookies'], '/cookies.txt')
+        self.assertTrue(data["success"])
+        self.assertEqual(ytj.config["output_dir"], "/new")
+        self.assertFalse(ytj.config["use_h265"])
+        self.assertEqual(ytj.config["cookies"], "/cookies.txt")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_job_management.py
+++ b/tests/test_job_management.py
@@ -7,45 +7,42 @@ import json
 from unittest.mock import patch, MagicMock, call
 
 # Add parent directory to path to import app.py
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from tubarr.core import YTToJellyfin, DownloadJob
 
+
 class TestJobManagement(unittest.TestCase):
-    
+
     def setUp(self):
         # Create a temporary directory for testing
         self.temp_dir = tempfile.mkdtemp()
         # Create app instance with test config
         self.app = YTToJellyfin()
         self.app.config = {
-            'output_dir': self.temp_dir,
-            'quality': '720',
-            'use_h265': True,
-            'crf': 28,
-            'ytdlp_path': 'yt-dlp',
-            'cookies': '',
-            'completed_jobs_limit': 3,
-            'update_checker_enabled': False,
-            'update_checker_interval': 60
+            "output_dir": self.temp_dir,
+            "quality": "720",
+            "use_h265": True,
+            "crf": 28,
+            "ytdlp_path": "yt-dlp",
+            "cookies": "",
+            "completed_jobs_limit": 3,
+            "update_checker_enabled": False,
+            "update_checker_interval": 60,
         }
         # Clear jobs
         self.app.jobs = {}
-    
+
     def tearDown(self):
         # Clean up temp directory
         shutil.rmtree(self.temp_dir, ignore_errors=True)
-    
+
     def test_download_job_creation(self):
         """Test creating a DownloadJob"""
         job = DownloadJob(
-            "test-id", 
-            "https://youtube.com/playlist?list=TEST",
-            "Test Show",
-            "01",
-            "01"
+            "test-id", "https://youtube.com/playlist?list=TEST", "Test Show", "01", "01"
         )
-        
+
         self.assertEqual(job.job_id, "test-id")
         self.assertEqual(job.playlist_url, "https://youtube.com/playlist?list=TEST")
         self.assertEqual(job.show_name, "Test Show")
@@ -54,38 +51,38 @@ class TestJobManagement(unittest.TestCase):
         self.assertEqual(job.status, "queued")
         self.assertEqual(job.progress, 0)
         self.assertEqual(job.messages, [])
-    
+
     def test_job_update(self):
         """Test updating job status and progress"""
         job = DownloadJob("test-id", "", "", "", "")
-        
+
         # Update status
         job.update(status="downloading")
         self.assertEqual(job.status, "downloading")
-        
+
         # Update progress
         job.update(progress=50)
         self.assertEqual(job.progress, 50)
-        
+
         # Update with message
         job.update(message="Starting download")
         self.assertEqual(len(job.messages), 1)
         self.assertEqual(job.messages[0]["text"], "Starting download")
-        
+
         # Multiple updates
         job.update(status="converting", progress=75, message="Converting video")
         self.assertEqual(job.status, "converting")
         self.assertEqual(job.progress, 75)
         self.assertEqual(len(job.messages), 2)
         self.assertEqual(job.messages[1]["text"], "Converting video")
-    
+
     def test_job_to_dict(self):
         """Test conversion of job to dictionary"""
         job = DownloadJob("test-id", "url", "show", "01", "01")
         job.update(status="downloading", progress=30, message="Starting download")
-        
+
         job_dict = job.to_dict()
-        
+
         self.assertEqual(job_dict["job_id"], "test-id")
         self.assertEqual(job_dict["playlist_url"], "url")
         self.assertEqual(job_dict["show_name"], "show")
@@ -94,24 +91,21 @@ class TestJobManagement(unittest.TestCase):
         self.assertEqual(job_dict["status"], "downloading")
         self.assertEqual(job_dict["progress"], 30)
         self.assertEqual(len(job_dict["messages"]), 1)
-    
-    @patch.object(YTToJellyfin, '_register_playlist')
-    @patch('threading.Thread')
+
+    @patch.object(YTToJellyfin, "_register_playlist")
+    @patch("threading.Thread")
     def test_create_job(self, mock_thread, mock_register):
         """Test job creation in the app"""
         job_id = self.app.create_job(
-            "https://youtube.com/playlist?list=TEST",
-            "Test Show",
-            "01",
-            "01"
+            "https://youtube.com/playlist?list=TEST", "Test Show", "01", "01"
         )
-        
+
         # Verify job was created and stored
         self.assertIn(job_id, self.app.jobs)
         job = self.app.jobs[job_id]
         self.assertEqual(job.playlist_url, "https://youtube.com/playlist?list=TEST")
         self.assertEqual(job.show_name, "Test Show")
-        
+
         # Verify playlist was registered and thread started
         mock_register.assert_called_once_with(
             "https://youtube.com/playlist?list=TEST", "Test Show", "01"
@@ -119,22 +113,19 @@ class TestJobManagement(unittest.TestCase):
         mock_thread.assert_called_once()
         mock_thread.return_value.start.assert_called_once()
 
-    @patch.object(YTToJellyfin, '_register_playlist')
-    @patch('threading.Thread')
+    @patch.object(YTToJellyfin, "_register_playlist")
+    @patch("threading.Thread")
     def test_create_job_single_video_not_registered(self, mock_thread, mock_register):
         """Single video URLs should not register playlists"""
         job_id = self.app.create_job(
-            "https://youtube.com/watch?v=abc123",
-            "Video Show",
-            "01",
-            "01"
+            "https://youtube.com/watch?v=abc123", "Video Show", "01", "01"
         )
 
         self.assertIn(job_id, self.app.jobs)
         mock_register.assert_not_called()
         mock_thread.assert_called_once()
         mock_thread.return_value.start.assert_called_once()
-    
+
     def test_job_limit_enforcement(self):
         """Test that completed jobs limit is enforced"""
         # Create more jobs than the limit
@@ -144,22 +135,24 @@ class TestJobManagement(unittest.TestCase):
             job = DownloadJob(job_id, "url", "show", "01", "01")
             job.update(status="completed")
             self.app.jobs[job_id] = job
-        
+
         # Add a new job, which should trigger cleanup
-        with patch('uuid.uuid4', return_value="new-job"):
+        with patch("uuid.uuid4", return_value="new-job"):
             self.app.create_job("url", "show", "01", "01")
-        
+
         # Verify we only have the limit + 1 (the new job) jobs
-        self.assertEqual(len(self.app.jobs), self.app.config['completed_jobs_limit'] + 1)
+        self.assertEqual(
+            len(self.app.jobs), self.app.config["completed_jobs_limit"] + 1
+        )
         # Verify the newest completed job and the new job are kept
         self.assertIn("job-4", self.app.jobs)
         self.assertIn("new-job", self.app.jobs)
         # Verify oldest completed jobs were removed
         self.assertNotIn("job-0", self.app.jobs)
         self.assertNotIn("job-1", self.app.jobs)
-    
-    @patch('subprocess.Popen')
-    @patch('subprocess.run')
+
+    @patch("subprocess.Popen")
+    @patch("subprocess.run")
     def test_download_playlist(self, mock_run, mock_popen):
         """Test playlist download function"""
         # Mock the process
@@ -167,29 +160,29 @@ class TestJobManagement(unittest.TestCase):
         process_mock.stdout = ["[download] 10.0% of 100.00MB", "Done!"]
         process_mock.returncode = 0
         mock_popen.return_value = process_mock
-        
+
         # Create a job
         job_id = "test-job"
         job = DownloadJob(job_id, "url", "show", "01", "01")
         self.app.jobs[job_id] = job
-        
+
         # Execute download
         result = self.app.download_playlist("url", self.temp_dir, "01", job_id)
-        
+
         # Verify success
         self.assertTrue(result)
         self.assertEqual(job.status, "downloaded")
         self.assertEqual(job.progress, 100)
-        
+
         # Verify command was correct
         mock_popen.assert_called_once()
         cmd_args = mock_popen.call_args[0][0]
-        self.assertEqual(cmd_args[0], 'yt-dlp')
-        self.assertIn('--merge-output-format', cmd_args)
-        self.assertIn('mp4', cmd_args)
-        self.assertIn('url', cmd_args)
-    
-    @patch('subprocess.Popen')
+        self.assertEqual(cmd_args[0], "yt-dlp")
+        self.assertIn("--merge-output-format", cmd_args)
+        self.assertIn("mp4", cmd_args)
+        self.assertIn("url", cmd_args)
+
+    @patch("subprocess.Popen")
     def test_download_failure(self, mock_popen):
         """Test handling of download failures"""
         # Mock the process with failure
@@ -197,144 +190,189 @@ class TestJobManagement(unittest.TestCase):
         process_mock.stdout = ["ERROR: Unable to download"]
         process_mock.returncode = 1
         mock_popen.return_value = process_mock
-        
+
         # Create a job
         job_id = "test-job"
         job = DownloadJob(job_id, "url", "show", "01", "01")
         self.app.jobs[job_id] = job
-        
+
         # Execute download
         result = self.app.download_playlist("url", self.temp_dir, "01", job_id)
-        
+
         # Verify failure
         self.assertFalse(result)
         self.assertEqual(job.status, "failed")
-    
-    @patch('os.path.exists')
-    @patch('json.load')
-    @patch('builtins.open', new_callable=unittest.mock.mock_open)
-    @patch('os.remove')
-    @patch('os.rename')
-    def test_process_metadata(self, mock_rename, mock_remove, mock_open, mock_json_load, mock_exists):
+
+    @patch("os.path.exists")
+    @patch("json.load")
+    @patch("builtins.open", new_callable=unittest.mock.mock_open)
+    @patch("os.remove")
+    @patch("os.rename")
+    def test_process_metadata(
+        self, mock_rename, mock_remove, mock_open, mock_json_load, mock_exists
+    ):
         """Test metadata processing"""
         # Setup mocks
         # Only mp4 and json files should be considered existing
-        mock_exists.side_effect = lambda p: p.endswith('.mp4') or p.endswith('.info.json')
+        mock_exists.side_effect = lambda p: p.endswith(".mp4") or p.endswith(
+            ".info.json"
+        )
         mock_json_load.side_effect = [
             # First JSON file (to get first index)
-            {'playlist_index': 1},
+            {"playlist_index": 1},
             # Individual JSON files
-            {'title': 'Video 1', 'description': 'Desc 1', 'upload_date': '20230101', 'playlist_index': 1},
-            {'title': 'Video 2', 'description': 'Desc 2', 'upload_date': '20230102', 'playlist_index': 2}
+            {
+                "title": "Video 1",
+                "description": "Desc 1",
+                "upload_date": "20230101",
+                "playlist_index": 1,
+            },
+            {
+                "title": "Video 2",
+                "description": "Desc 2",
+                "upload_date": "20230102",
+                "playlist_index": 2,
+            },
         ]
-        
+
         # Mock Path.glob to return two JSON files
-        with patch('pathlib.Path.glob') as mock_glob:
+        with patch("pathlib.Path.glob") as mock_glob:
             mock_glob.return_value = [
-                MagicMock(__str__=lambda self: f"{self.temp_dir}/Test Show S01E01.info.json"),
-                MagicMock(__str__=lambda self: f"{self.temp_dir}/Test Show S01E02.info.json")
+                MagicMock(
+                    __str__=lambda self: f"{self.temp_dir}/Test Show S01E01.info.json"
+                ),
+                MagicMock(
+                    __str__=lambda self: f"{self.temp_dir}/Test Show S01E02.info.json"
+                ),
             ]
-            
+
             # Create a job
             job_id = "test-job"
             job = DownloadJob(job_id, "url", "Test Show", "01", "01")
             self.app.jobs[job_id] = job
-            
+
             # Process metadata
             self.app.process_metadata(self.temp_dir, "Test Show", "01", 1, job_id)
-            
+
             # Verify job was updated
             self.assertEqual(job.status, "processing_metadata")
-            self.assertEqual(job.progress, 100)  # Should be 100% after processing two files
-            
+            self.assertEqual(
+                job.progress, 100
+            )  # Should be 100% after processing two files
+
             # Verify files were processed
-            self.assertEqual(mock_open.call_count, 5)  # 3 reads (first index + 2 files) + 2 NFO writes
+            self.assertEqual(
+                mock_open.call_count, 5
+            )  # 3 reads (first index + 2 files) + 2 NFO writes
             self.assertEqual(mock_remove.call_count, 2)  # Remove two JSON files
             self.assertEqual(mock_rename.call_count, 2)  # Rename two video files
-    
+
     def test_get_job(self):
         """Test getting a specific job"""
         # Add test jobs
         job1 = DownloadJob("job1", "url1", "show1", "01", "01")
         job2 = DownloadJob("job2", "url2", "show2", "02", "01")
         self.app.jobs = {"job1": job1, "job2": job2}
-        
+
         # Get existing job
         job = self.app.get_job("job1")
         self.assertEqual(job["job_id"], "job1")
         self.assertEqual(job["show_name"], "show1")
-        
+
         # Get non-existent job
         job = self.app.get_job("job3")
         self.assertIsNone(job)
-    
+
     def test_get_jobs(self):
         """Test getting all jobs"""
         # Add test jobs
         job1 = DownloadJob("job1", "url1", "show1", "01", "01")
         job2 = DownloadJob("job2", "url2", "show2", "02", "01")
         self.app.jobs = {"job1": job1, "job2": job2}
-        
+
         # Get all jobs
         jobs = self.app.get_jobs()
         self.assertEqual(len(jobs), 2)
         self.assertTrue(any(j["job_id"] == "job1" for j in jobs))
         self.assertTrue(any(j["job_id"] == "job2" for j in jobs))
 
-    @patch('subprocess.run')
+    def test_cancel_job(self):
+        """Cancelling a running job should terminate its process."""
+        job_id = "job1"
+        job = DownloadJob(job_id, "url", "show", "01", "01")
+        job.status = "downloading"
+        proc = MagicMock()
+        proc.poll.return_value = None
+        job.process = proc
+        self.app.jobs[job_id] = job
+
+        result = self.app.cancel_job(job_id)
+
+        self.assertTrue(result)
+        proc.terminate.assert_called_once()
+        self.assertEqual(job.status, "cancelled")
+        self.assertIsNone(job.process)
+
+    def test_cancel_job_not_found(self):
+        """Cancelling a missing job should return False."""
+        result = self.app.cancel_job("missing")
+        self.assertFalse(result)
+
+    @patch("subprocess.run")
     def test_check_playlist_updates_creates_job(self, mock_run):
         """Ensure a new job is created when playlist has new items."""
         # Setup playlist info
-        archive = os.path.join(self.temp_dir, 'TEST.txt')
-        with open(archive, 'w') as f:
-            f.write('oldid\n')
+        archive = os.path.join(self.temp_dir, "TEST.txt")
+        with open(archive, "w") as f:
+            f.write("oldid\n")
 
         self.app.playlists = {
-            'TEST': {
-                'url': 'https://youtube.com/playlist?list=TEST',
-                'show_name': 'Test Show',
-                'season_num': '01',
-                'archive': archive,
+            "TEST": {
+                "url": "https://youtube.com/playlist?list=TEST",
+                "show_name": "Test Show",
+                "season_num": "01",
+                "archive": archive,
             }
         }
-        self.app.config['ytdlp_path'] = 'yt-dlp'
+        self.app.config["ytdlp_path"] = "yt-dlp"
 
         # yt-dlp returns a playlist with one old id and one new id
         mock_run.return_value = MagicMock(
-            stdout=json.dumps({'entries': [{'id': 'oldid'}, {'id': 'newid'}]}),
+            stdout=json.dumps({"entries": [{"id": "oldid"}, {"id": "newid"}]}),
             returncode=0,
         )
 
-        with patch.object(self.app, 'create_job', return_value='job-1') as mock_create:
+        with patch.object(self.app, "create_job", return_value="job-1") as mock_create:
             jobs = self.app.check_playlist_updates()
             mock_create.assert_called_once_with(
-                'https://youtube.com/playlist?list=TEST', 'Test Show', '01', '01'
+                "https://youtube.com/playlist?list=TEST", "Test Show", "01", "01"
             )
-            self.assertEqual(jobs, ['job-1'])
+            self.assertEqual(jobs, ["job-1"])
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_check_playlist_updates_no_new_videos(self, mock_run):
         """No job should be created when there are no new videos."""
-        archive = os.path.join(self.temp_dir, 'TEST.txt')
-        with open(archive, 'w') as f:
-            f.write('id1\n')
+        archive = os.path.join(self.temp_dir, "TEST.txt")
+        with open(archive, "w") as f:
+            f.write("id1\n")
 
         self.app.playlists = {
-            'TEST': {
-                'url': 'https://youtube.com/playlist?list=TEST',
-                'show_name': 'Test Show',
-                'season_num': '01',
-                'archive': archive,
+            "TEST": {
+                "url": "https://youtube.com/playlist?list=TEST",
+                "show_name": "Test Show",
+                "season_num": "01",
+                "archive": archive,
             }
         }
         mock_run.return_value = MagicMock(
-            stdout=json.dumps({'entries': [{'id': 'id1'}]}), returncode=0
+            stdout=json.dumps({"entries": [{"id": "id1"}]}), returncode=0
         )
 
-        with patch.object(self.app, 'create_job') as mock_create:
+        with patch.object(self.app, "create_job") as mock_create:
             jobs = self.app.check_playlist_updates()
             mock_create.assert_not_called()
             self.assertEqual(jobs, [])
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -387,6 +387,7 @@
                                 </div>
                                 <div class="modal-footer">
                                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                                    <button type="button" class="btn btn-danger" id="cancel-job-btn">Cancel Job</button>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- track running subprocess handles on `DownloadJob`
- implement `cancel_job` to terminate active processes
- expose DELETE `/jobs/<job_id>` API endpoint
- add cancellation button in web UI
- refresh job status after cancellation
- test cancellation logic in core and API layers

## Testing
- `flake8 .`
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6844b91748c08323ae26695bef94a577