### PR TITLE
Add episode tracker for playlists

### DIFF
--- a/tests/test_job_management.py
+++ b/tests/test_job_management.py
@@ -262,8 +262,8 @@ class TestJobManagement(unittest.TestCase):
 
             # Verify files were processed
             self.assertEqual(
-                mock_open.call_count, 5
-            )  # 3 reads (first index + 2 files) + 2 NFO writes
+                mock_open.call_count, 6
+            )  # 3 reads + 2 NFO writes + 1 tracker save
             self.assertEqual(mock_remove.call_count, 2)  # Remove two JSON files
             self.assertEqual(mock_rename.call_count, 2)  # Rename two video files
 

--- a/tests/test_playlist_ops.py
+++ b/tests/test_playlist_ops.py
@@ -59,6 +59,7 @@ class TestPlaylistOperations(unittest.TestCase):
         with open(archive, 'w') as f:
             f.write('id1\n')
             f.write('id2\n')
+        self.app.update_last_episode('Test Show', '01', 2)
         playlists = self.app.list_playlists()
         self.assertEqual(len(playlists), 1)
         info = playlists[0]

--- a/tubarr/episodes.py
+++ b/tubarr/episodes.py
@@ -1,0 +1,46 @@
+import os
+import json
+from typing import Dict
+
+from .config import logger
+from .utils import sanitize_name
+
+
+def _load_episode_tracker(episodes_file: str) -> Dict[str, Dict[str, int]]:
+    if os.path.exists(episodes_file):
+        try:
+            with open(episodes_file, "r") as f:
+                return json.load(f)
+        except (IOError, json.JSONDecodeError):
+            logger.warning("Failed to load episode tracker, starting fresh")
+    return {}
+
+
+def _save_episode_tracker(episodes_file: str, data: Dict[str, Dict[str, int]]) -> None:
+    os.makedirs(os.path.dirname(episodes_file), exist_ok=True)
+    with open(episodes_file, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def get_last_episode(tracker: Dict[str, Dict[str, int]], show_name: str, season_num: str) -> int:
+    return tracker.get(sanitize_name(show_name), {}).get(season_num, 0)
+
+
+def update_last_episode(
+    tracker: Dict[str, Dict[str, int]],
+    episodes_file: str,
+    show_name: str,
+    season_num: str,
+    last_episode: int,
+) -> None:
+    key = sanitize_name(show_name)
+    tracker.setdefault(key, {})[season_num] = last_episode
+    _save_episode_tracker(episodes_file, tracker)
+
+
+__all__ = [
+    "_load_episode_tracker",
+    "_save_episode_tracker",
+    "get_last_episode",
+    "update_last_episode",
+]

--- a/tubarr/media.py
+++ b/tubarr/media.py
@@ -195,6 +195,9 @@ def process_metadata(app, folder: str, show_name: str, season_num: str, episode_
             progress = int((i + 1) / total_files * 100)
             job.update(progress=progress, stage_progress=progress, detailed_status=f"Processed {i+1} of {total_files} files")
 
+    last_episode = episode_start + total_files - 1
+    app.update_last_episode(show_name, season_num, last_episode)
+
 
 def convert_video_files(app, folder: str, season_num: str, job_id: str) -> None:
     if not app.config["use_h265"]:

--- a/tubarr/playlist.py
+++ b/tubarr/playlist.py
@@ -91,8 +91,11 @@ def check_playlist_updates(app) -> List[str]:
             logger.info(f"No updates found for playlist {info['url']}")
             continue
 
-        folder = app.create_folder_structure(info["show_name"], info["season_num"])
-        start = _get_existing_max_index(folder, info["season_num"]) + 1
+        folder = app.create_folder_structure(info["show_name"], info["season_num"]) 
+        last_ep = app.get_last_episode(info["show_name"], info["season_num"]) 
+        if last_ep == 0:
+            last_ep = _get_existing_max_index(folder, info["season_num"])
+        start = last_ep + 1
         job_id = app.create_job(info["url"], info["show_name"], info["season_num"], str(start).zfill(2))
         created_jobs.append(job_id)
     return created_jobs


### PR DESCRIPTION
## Summary
- add new `episodes.py` tracker module
- track last episode separately from playlist downloads
- update metadata processing to store last episode
- ensure playlist update checker and playlist listing use the tracker
- adapt tests for new tracker

## Testing
- `python run_tests.py --type basic`
- `python run_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_6844ca0941288323bdca4c5b65e9c487