### PR TITLE
Add config validation with Pydantic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pyyaml>=6.0
 flask>=2.2.0
 gunicorn>=20.1.0
 waitress>=2.1.2
+pydantic>=2.1

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -70,7 +70,7 @@ class TestYTToJellyfin(unittest.TestCase):
         config = app.config
 
         self.assertEqual(config['output_dir'], '/env/media')
-        self.assertEqual(config['quality'], '480')
+        self.assertEqual(config['quality'], 480)
         self.assertFalse(config['use_h265'])
         self.assertEqual(config['crf'], 23)
         self.assertEqual(config['ytdlp_path'], '/usr/bin/ytdlp')

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,35 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from tubarr.config import _load_config
+
+class TestConfigValidation(unittest.TestCase):
+    def test_invalid_web_port(self):
+        env = {
+            'WEB_PORT': '70000',
+        }
+        with patch.dict(os.environ, env, clear=True), \
+             patch('os.path.exists', side_effect=lambda p: False if p == 'config/config.yml' else True), \
+             patch('os.access', return_value=True):
+            with self.assertRaises(ValueError):
+                _load_config()
+
+    def test_invalid_crf(self):
+        env = {'CRF': '100'}
+        with patch.dict(os.environ, env, clear=True), \
+             patch('os.path.exists', side_effect=lambda p: False if p == 'config/config.yml' else True), \
+             patch('os.access', return_value=True):
+            with self.assertRaises(ValueError):
+                _load_config()
+
+    def test_missing_output_dir(self):
+        env = {'OUTPUT_DIR': ''}
+        with patch.dict(os.environ, env, clear=True), \
+             patch('os.path.exists', side_effect=lambda p: False if p == 'config/config.yml' else True), \
+             patch('os.access', return_value=True):
+            with self.assertRaises(ValueError):
+                _load_config()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- introduce `ConfigModel` using pydantic with type/range checks
- validate configuration on load and raise ValueError on failure
- add pydantic to requirements
- adjust existing test for integer `quality`
- add new tests covering invalid configuration values

## Testing
- `flake8 .`
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_684542251828832380c4d76ad122cb8c