### PR TITLE
Use logo in sidebar

### DIFF
--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -16,7 +16,7 @@
             <nav class="col-md-3 col-lg-2 d-md-block bg-dark sidebar collapse">
                 <div class="position-sticky pt-3">
                     <div class="text-center mb-4">
-                        <h3 class="text-white">Tubarr</h3>
+                        <img src="{{ url_for('static', filename='logo.png') }}" alt="Tubarr" class="img-fluid" style="max-width: 150px;">
                     </div>
                     <ul class="nav flex-column">
                         <li class="nav-item">


### PR DESCRIPTION
## Summary
- use `logo.png` image instead of text in sidebar header

## Testing
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6845983358808323ab035ebc90a142e6