### PR TITLE
Add poster-based media library view

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -146,6 +146,20 @@ class TestAPIEndpoints(unittest.TestCase):
         self.assertEqual(len(data[0]["seasons"]), 1)
         self.assertEqual(len(data[0]["seasons"][0]["episodes"]), 1)
 
+    def test_media_files_endpoint(self):
+        """Test serving of media files"""
+        with tempfile.TemporaryDirectory() as tempdir:
+            ytj.config["output_dir"] = tempdir
+            show_dir = os.path.join(tempdir, "Test Show")
+            os.makedirs(show_dir, exist_ok=True)
+            poster = os.path.join(show_dir, "poster.jpg")
+            with open(poster, "wb") as f:
+                f.write(b"data")
+
+            rel_path = os.path.relpath(poster, tempdir)
+            response = self.client.get(f"/media_files/{rel_path}")
+            self.assertEqual(response.status_code, 200)
+
     def test_get_config(self):
         """Test configuration endpoint"""
         # Set some config values

--- a/tubarr/web.py
+++ b/tubarr/web.py
@@ -89,6 +89,13 @@ def media():
     return jsonify(ytj.list_media())
 
 
+@app.route("/media_files/<path:filename>")
+def media_files(filename):
+    """Serve media files such as posters."""
+    output_dir = ytj.config.get("output_dir", "")
+    return send_from_directory(output_dir, filename)
+
+
 @app.route("/playlists", methods=["GET"])
 def playlists():
     """Return registered playlists."""

--- a/web/static/script.js
+++ b/web/static/script.js
@@ -694,38 +694,58 @@ function loadMedia() {
 function displayMediaLibrary(media) {
     const mediaContainer = document.getElementById('media-container');
     mediaContainer.innerHTML = '';
-    
+
     if (media.length === 0) {
         mediaContainer.innerHTML = '<div class="alert alert-info">No media found in library</div>';
         return;
     }
-    
+
+    const row = document.createElement('div');
+    row.className = 'row';
+
     media.forEach(show => {
-        const showCard = document.createElement('div');
-        showCard.className = 'card shadow mb-4';
-        
-        showCard.innerHTML = `
-            <div class="card-header py-3 d-flex justify-content-between align-items-center">
-                <h6 class="m-0 font-weight-bold">${show.name}</h6>
-                <span class="badge bg-secondary">${show.seasons.length} Seasons</span>
-            </div>
-            <div class="card-body">
-                <div class="row seasons-container-${show.name.replace(/[^a-zA-Z0-9]/g, '_')}">
-                    ${show.seasons.map(season => createSeasonCard(season)).join('')}
+        const showId = show.name.replace(/[^a-zA-Z0-9]/g, '_');
+        const totalEpisodes = show.episode_count || 0;
+        const posterUrl = show.poster ? `/media_files/${encodeURIComponent(show.poster)}` : null;
+
+        const col = document.createElement('div');
+        col.className = 'col-sm-6 col-md-4 col-lg-3 mb-4';
+
+        col.innerHTML = `
+            <div class="card h-100 show-card" data-show-id="${showId}">
+                <div class="show-poster-container position-relative">
+                    ${posterUrl ? `<img src="${posterUrl}" class="show-poster" alt="${show.name}">` : `<div class="show-poster bg-secondary d-flex align-items-center justify-content-center"><i class="bi bi-tv text-white" style="font-size: 3rem;"></i></div>`}
+                    <span class="badge bg-primary position-absolute top-0 end-0 m-2">${totalEpisodes}</span>
+                </div>
+                <div class="card-body text-center">
+                    <h5 class="card-title">${show.name}</h5>
                 </div>
             </div>
+            <div id="show-seasons-${showId}" class="row mt-2 d-none">
+                ${show.seasons.map(season => createSeasonCard(season)).join('')}
+            </div>
         `;
-        
-        mediaContainer.appendChild(showCard);
+
+        row.appendChild(col);
     });
-    
-    // Add click handlers for season cards
+
+    mediaContainer.appendChild(row);
+
+    document.querySelectorAll('.show-card').forEach(card => {
+        card.addEventListener('click', function() {
+            const showId = this.getAttribute('data-show-id');
+            const seasonsContainer = document.getElementById(`show-seasons-${showId}`);
+            if (seasonsContainer) {
+                seasonsContainer.classList.toggle('d-none');
+            }
+        });
+    });
+
     document.querySelectorAll('.season-card').forEach(card => {
         card.addEventListener('click', function() {
             const seasonId = this.getAttribute('data-season-id');
             const episodeContainer = document.getElementById(`episode-container-${seasonId}`);
-            
-            // Toggle visibility
+
             if (episodeContainer.classList.contains('d-none')) {
                 episodeContainer.classList.remove('d-none');
                 this.querySelector('.toggle-icon').classList.replace('bi-plus', 'bi-dash');
@@ -740,14 +760,13 @@ function displayMediaLibrary(media) {
 function createSeasonCard(season) {
     const seasonId = season.name.replace(/[^a-zA-Z0-9]/g, '_');
     const episodeCount = season.episodes.length;
-    
+    const posterUrl = season.poster ? `/media_files/${encodeURIComponent(season.poster)}` : null;
+
     return `
         <div class="col-md-6 col-lg-4 mb-4">
             <div class="card media-card">
                 <div class="season-poster-container">
-                    <div class="season-poster bg-secondary d-flex align-items-center justify-content-center">
-                        <i class="bi bi-film text-white" style="font-size: 3rem;"></i>
-                    </div>
+                    ${posterUrl ? `<img src="${posterUrl}" class="season-poster" alt="${season.name}">` : `<div class="season-poster bg-secondary d-flex align-items-center justify-content-center"><i class="bi bi-film text-white" style="font-size: 3rem;"></i></div>`}
                 </div>
                 <div class="card-body">
                     <h5 class="card-title">${season.name}</h5>

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -149,6 +149,10 @@ main {
     object-fit: cover;
 }
 
+.show-card {
+    cursor: pointer;
+}
+
 .season-poster-container {
     position: relative;
     padding-top: 56.25%; /* 16:9 aspect ratio */


### PR DESCRIPTION
## Summary
- enhance list_media to include poster paths and episode counts
- serve media files through new /media_files endpoint
- redesign media library to display show and season posters
- update styles for clickable show cards
- add test for media_files endpoint

## Testing
- `flake8 .`
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68459a7e185c8323a330e99f59b305bf