### PR TITLE
Fix poster 404s

### DIFF
--- a/tubarr/config.py
+++ b/tubarr/config.py
@@ -142,6 +142,9 @@ def _load_config() -> Dict:
         except (yaml.YAMLError, IOError) as e:
             logger.error(f"Error loading config file: {e}")
 
+    # Ensure output_dir is absolute so file serving works regardless of current working directory
+    config["output_dir"] = os.path.abspath(config["output_dir"])
+
     try:
         validated = ConfigModel(**config)
     except ValidationError as e:


### PR DESCRIPTION
## Summary
- ensure the configured media directory is an absolute path so Flask can serve posters

## Testing
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6845a33bbbdc8323a6e3af5e83226788