### PR TITLE
Implement playlist start index tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ When adding a new playlist you can disable tracking if you don't want Tubarr to
 monitor it for future updates. Tracking can also be toggled or the playlist
 removed later from the **Playlists** page.
 
+If you want to start downloading from a specific video in a playlist, set the
+"Playlist Start" number when creating a job. Tubarr records this index and skips
+earlier videos when checking for updates.
+
 To check all saved playlists for newly added videos you can:
 
 - Run `python app.py --check-updates` from the command line.

--- a/roadmap.md
+++ b/roadmap.md
@@ -3,6 +3,7 @@
 The following are planned improvements and tasks for Tubarr:
 
 - Separate tracking season/episode position from playlist position so adding a single video to a season does not affect automatic playlist downloads.
+- Track the starting playlist index to avoid downloading earlier videos when updates are checked.
 - Option to enable / disable playlist tracking when adding and when added
 - Display all downloaded episodes in the media library and show a drop-down in the playlist view listing episodes downloaded from that playlist.
 - **Add missing MIT license**. The README references a license but none existed.

--- a/tests/test_additional.py
+++ b/tests/test_additional.py
@@ -7,10 +7,12 @@ from pathlib import Path
 
 # Ensure app.py can be imported
 import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from tubarr.core import YTToJellyfin
 from tubarr.web import app, ytj
 import subprocess
+
 
 class TestConfigAndDependencies(unittest.TestCase):
     def setUp(self):
@@ -22,101 +24,114 @@ class TestConfigAndDependencies(unittest.TestCase):
         self.env_patcher.stop()
 
     def test_load_config_from_env(self):
-        os.environ['OUTPUT_DIR'] = '/tmp/media'
-        os.environ['VIDEO_QUALITY'] = '720'
-        os.environ['USE_H265'] = 'false'
-        os.environ['COOKIES_PATH'] = '/tmp/cookies.txt'
-        os.environ['CONFIG_FILE'] = '/tmp/does_not_exist.yml'
-        Path('/tmp/cookies.txt').write_text('cookies')
+        os.environ["OUTPUT_DIR"] = "/tmp/media"
+        os.environ["VIDEO_QUALITY"] = "720"
+        os.environ["USE_H265"] = "false"
+        os.environ["COOKIES_PATH"] = "/tmp/cookies.txt"
+        os.environ["CONFIG_FILE"] = "/tmp/does_not_exist.yml"
+        Path("/tmp/cookies.txt").write_text("cookies")
 
         yt = YTToJellyfin()
-        self.assertEqual(yt.config['output_dir'], '/tmp/media')
-        self.assertEqual(yt.config['quality'], '720')
-        self.assertFalse(yt.config['use_h265'])
-        self.assertEqual(yt.config['cookies'], '/tmp/cookies.txt')
+        self.assertEqual(yt.config["output_dir"], "/tmp/media")
+        self.assertEqual(yt.config["quality"], "720")
+        self.assertFalse(yt.config["use_h265"])
+        self.assertEqual(yt.config["cookies"], "/tmp/cookies.txt")
 
-    @patch('subprocess.run')
-    @patch('os.access', return_value=True)
-    @patch('os.path.exists', return_value=True)
+    @patch("subprocess.run")
+    @patch("os.access", return_value=True)
+    @patch("os.path.exists", return_value=True)
     def test_check_dependencies(self, mock_exists, mock_access, mock_run):
-        mock_run.return_value = MagicMock(returncode=0, stdout='/usr/bin/tool')
+        mock_run.return_value = MagicMock(returncode=0, stdout="/usr/bin/tool")
         yt = YTToJellyfin()
-        yt.config['ytdlp_path'] = '/usr/bin/yt-dlp'
+        yt.config["ytdlp_path"] = "/usr/bin/yt-dlp"
         self.assertTrue(yt.check_dependencies())
 
-        mock_run.side_effect = [MagicMock(returncode=0, stdout=''), subprocess.CalledProcessError(1, ['which','ffmpeg'])]
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=""),
+            subprocess.CalledProcessError(1, ["which", "ffmpeg"]),
+        ]
         self.assertFalse(yt.check_dependencies())
+
 
 class TestPlaylistHelpers(unittest.TestCase):
     def setUp(self):
         self.temp_dir = tempfile.mkdtemp()
         self.yt = YTToJellyfin()
-        self.yt.config['output_dir'] = self.temp_dir
+        self.yt.config["output_dir"] = self.temp_dir
 
     def tearDown(self):
         import shutil
+
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
     def test_get_existing_max_index(self):
         folder = Path(self.temp_dir)
-        (folder / 'Show S01E01.mp4').touch()
-        (folder / 'Show S01E03.mp4').touch()
-        idx = self.yt._get_existing_max_index(self.temp_dir, '01')
+        (folder / "Show S01E01.mp4").touch()
+        (folder / "Show S01E03.mp4").touch()
+        idx = self.yt._get_existing_max_index(self.temp_dir, "01")
         self.assertEqual(idx, 3)
 
     def test_register_playlist(self):
-        with patch.object(self.yt, '_save_playlists') as mock_save:
-            self.yt._register_playlist('https://youtube.com/playlist?list=ABC', 'Show', '01')
-            self.assertIn('ABC', self.yt.playlists)
+        with patch.object(self.yt, "_save_playlists") as mock_save:
+            self.yt._register_playlist(
+                "https://youtube.com/playlist?list=ABC", "Show", "01", None
+            )
+            self.assertIn("ABC", self.yt.playlists)
             mock_save.assert_called_once()
+
 
 class TestConversionWorkflow(unittest.TestCase):
     def setUp(self):
         self.temp_dir = tempfile.mkdtemp()
         self.yt = YTToJellyfin()
-        self.yt.config['output_dir'] = self.temp_dir
-        self.yt.config['use_h265'] = False
+        self.yt.config["output_dir"] = self.temp_dir
+        self.yt.config["use_h265"] = False
         job = MagicMock()
-        self.yt.jobs['job'] = job
+        self.yt.jobs["job"] = job
 
     def tearDown(self):
         import shutil
+
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
     def test_convert_video_files_disabled(self):
-        self.yt.convert_video_files(self.temp_dir, '01', 'job')
-        job = self.yt.jobs['job']
+        self.yt.convert_video_files(self.temp_dir, "01", "job")
+        job = self.yt.jobs["job"]
         job.update.assert_called()
-        self.assertIn('H.265 conversion disabled', job.update.call_args.kwargs.get('message'))
+        self.assertIn(
+            "H.265 conversion disabled", job.update.call_args.kwargs.get("message")
+        )
+
 
 class TestAPIExtensions(unittest.TestCase):
     def setUp(self):
-        app.config['TESTING'] = True
+        app.config["TESTING"] = True
         self.client = app.test_client()
         ytj.playlists = {}
 
     def test_playlist_info_missing(self):
-        resp = self.client.get('/playlist_info')
+        resp = self.client.get("/playlist_info")
         self.assertEqual(resp.status_code, 400)
 
-    @patch.object(YTToJellyfin, 'get_playlist_videos', return_value={'entries': []})
+    @patch.object(YTToJellyfin, "get_playlist_videos", return_value={"entries": []})
     def test_playlist_info(self, mock_get):
-        resp = self.client.get('/playlist_info?url=test')
+        resp = self.client.get("/playlist_info?url=test")
         self.assertEqual(resp.status_code, 200)
-        mock_get.assert_called_once_with('test')
+        mock_get.assert_called_once_with("test")
 
-    @patch.object(YTToJellyfin, 'check_playlist_updates', return_value=['job1'])
+    @patch.object(YTToJellyfin, "check_playlist_updates", return_value=["job1"])
     def test_playlists_check(self, mock_check):
-        resp = self.client.post('/playlists/check')
+        resp = self.client.post("/playlists/check")
         self.assertEqual(resp.status_code, 200)
         data = json.loads(resp.data)
-        self.assertEqual(data['created_jobs'], ['job1'])
+        self.assertEqual(data["created_jobs"], ["job1"])
 
     def test_config_put(self):
-        resp = self.client.put('/config', json={'quality': 480, 'use_h265': False})
+        resp = self.client.put("/config", json={"quality": 480, "use_h265": False})
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(ytj.config['quality'], 480)
-        self.assertFalse(ytj.config['use_h265'])
+        self.assertEqual(ytj.config["quality"], 480)
+        self.assertFalse(ytj.config["use_h265"])
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -52,6 +52,7 @@ class TestAPIEndpoints(unittest.TestCase):
             "Test Show",
             "01",
             "01",
+            playlist_start=None,
             track_playlist=True,
         )
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,146 +6,159 @@ import shutil
 from unittest.mock import patch, MagicMock, call
 
 # Add parent directory to path to import app.py
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from tubarr.core import YTToJellyfin, DownloadJob
+
 
 class TestIntegration(unittest.TestCase):
     """
     Integration tests for the complete workflow.
     These tests simulate a full download and processing without actually downloading from YouTube.
     """
-    
+
     def setUp(self):
         # Create a temporary directory for testing
         self.temp_dir = tempfile.mkdtemp()
-        self.output_dir = os.path.join(self.temp_dir, 'media')
+        self.output_dir = os.path.join(self.temp_dir, "media")
         os.makedirs(self.output_dir, exist_ok=True)
-        
+
         # Create app instance with test config
         self.app = YTToJellyfin()
         self.app.config = {
-            'output_dir': self.output_dir,
-            'quality': '720',
-            'use_h265': True,
-            'crf': 28,
-            'ytdlp_path': 'yt-dlp',
-            'cookies': '',
-            'completed_jobs_limit': 3,
-            'update_checker_enabled': False,
-            'update_checker_interval': 60
+            "output_dir": self.output_dir,
+            "quality": "720",
+            "use_h265": True,
+            "crf": 28,
+            "ytdlp_path": "yt-dlp",
+            "cookies": "",
+            "completed_jobs_limit": 3,
+            "update_checker_enabled": False,
+            "update_checker_interval": 60,
         }
         # Clear jobs
         self.app.jobs = {}
-    
+
     def tearDown(self):
         # Clean up temp directory
         shutil.rmtree(self.temp_dir, ignore_errors=True)
-    
-    @patch('threading.Thread')
-    @patch('app.YTToJellyfin.check_dependencies', return_value=True)
-    @patch('app.YTToJellyfin.download_playlist')
-    @patch('app.YTToJellyfin.process_metadata')
-    @patch('app.YTToJellyfin.convert_video_files')
-    @patch('app.YTToJellyfin.generate_artwork')
-    @patch('app.YTToJellyfin.create_nfo_files')
-    def test_full_workflow(self, mock_create_nfo, mock_generate_artwork,
-                           mock_convert, mock_process_metadata, mock_download,
-                           mock_check, mock_thread):
+
+    @patch("threading.Thread")
+    @patch("app.YTToJellyfin.check_dependencies", return_value=True)
+    @patch("app.YTToJellyfin.download_playlist")
+    @patch("app.YTToJellyfin.process_metadata")
+    @patch("app.YTToJellyfin.convert_video_files")
+    @patch("app.YTToJellyfin.generate_artwork")
+    @patch("app.YTToJellyfin.create_nfo_files")
+    def test_full_workflow(
+        self,
+        mock_create_nfo,
+        mock_generate_artwork,
+        mock_convert,
+        mock_process_metadata,
+        mock_download,
+        mock_check,
+        mock_thread,
+    ):
         """Test the full workflow from job creation to completion"""
         # Setup mocks
         mock_download.return_value = True
-        
+
         # Create a folder structure to simulate a successful download
-        show_dir = os.path.join(self.output_dir, 'Test Show')
-        season_dir = os.path.join(show_dir, 'Season 01')
+        show_dir = os.path.join(self.output_dir, "Test Show")
+        season_dir = os.path.join(show_dir, "Season 01")
         os.makedirs(season_dir, exist_ok=True)
-        
+
         # Create a sample video file
-        with open(os.path.join(season_dir, 'Test Show S01E01.mp4'), 'w') as f:
-            f.write('dummy video content')
-        
+        with open(os.path.join(season_dir, "Test Show S01E01.mp4"), "w") as f:
+            f.write("dummy video content")
+
         # Create a job
         job_id = self.app.create_job(
             "https://youtube.com/playlist?list=TEST",
             "Test Show",
             "01",
             "01",
-            start_thread=False
+            playlist_start=None,
+            start_thread=False,
         )
-        
+
         # Process the job
         self.app.process_job(job_id)
-        
+
         # Verify all steps were called in the correct order
         job = self.app.jobs[job_id]
         self.assertEqual(job.status, "completed")
         self.assertEqual(job.progress, 100)
-        
+
         # Check that all functions were called with correct parameters
         mock_download.assert_called_once_with(
             "https://youtube.com/playlist?list=TEST",
-            os.path.join(self.output_dir, 'Test Show', 'Season 01'),
+            os.path.join(self.output_dir, "Test Show", "Season 01"),
             "01",
-            job_id
+            job_id,
         )
-        
+
         mock_process_metadata.assert_called_once()
         mock_convert.assert_called_once()
         mock_generate_artwork.assert_called_once()
         mock_create_nfo.assert_called_once()
-    
-    @patch('threading.Thread')
-    @patch('app.YTToJellyfin.check_dependencies', return_value=True)
-    @patch('app.YTToJellyfin.download_playlist')
-    def test_workflow_with_download_failure(self, mock_download, mock_check, mock_thread):
+
+    @patch("threading.Thread")
+    @patch("app.YTToJellyfin.check_dependencies", return_value=True)
+    @patch("app.YTToJellyfin.download_playlist")
+    def test_workflow_with_download_failure(
+        self, mock_download, mock_check, mock_thread
+    ):
         """Test the workflow when download fails"""
         # Setup mock to simulate download failure
         mock_download.return_value = False
-        
+
         # Create a job
         job_id = self.app.create_job(
             "https://youtube.com/playlist?list=TEST",
             "Test Show",
             "01",
             "01",
-            start_thread=False
+            playlist_start=None,
+            start_thread=False,
         )
-        
+
         # Process the job
         self.app.process_job(job_id)
-        
+
         # Verify job status is failed
         job = self.app.jobs[job_id]
         self.assertEqual(job.status, "failed")
         self.assertIn("Download failed", job.messages[-1]["text"])
-    
-    @patch('app.YTToJellyfin.check_dependencies')
+
+    @patch("app.YTToJellyfin.check_dependencies")
     def test_workflow_with_missing_dependencies(self, mock_check_deps):
         """Test the workflow when dependencies are missing"""
         # Setup mock to simulate missing dependencies
         mock_check_deps.return_value = False
-        
+
         # Create a job
         job_id = self.app.create_job(
             "https://youtube.com/playlist?list=TEST",
             "Test Show",
             "01",
             "01",
-            start_thread=False
+            playlist_start=None,
+            start_thread=False,
         )
-        
+
         # Process the job
         self.app.process_job(job_id)
-        
+
         # Verify job status is failed
         job = self.app.jobs[job_id]
         self.assertEqual(job.status, "failed")
         self.assertIn("Missing dependencies", job.messages[-1]["text"])
-    
-    @patch('app.YTToJellyfin.download_playlist', return_value=True)
-    @patch('threading.Thread')
-    @patch('app.YTToJellyfin.check_dependencies', return_value=True)
+
+    @patch("app.YTToJellyfin.download_playlist", return_value=True)
+    @patch("threading.Thread")
+    @patch("app.YTToJellyfin.check_dependencies", return_value=True)
     def test_invalid_episode_start(self, mock_check, mock_thread, mock_download):
         """Test the workflow when episode_start is invalid"""
         # Create a job with invalid episode_start
@@ -154,18 +167,19 @@ class TestIntegration(unittest.TestCase):
             "Test Show",
             "01",
             "invalid",  # Non-numeric value
-            start_thread=False
+            playlist_start=None,
+            start_thread=False,
         )
-        
+
         # Process the job
         self.app.process_job(job_id)
-        
+
         # Verify job status is failed
         job = self.app.jobs[job_id]
         self.assertEqual(job.status, "failed")
         self.assertIn("Invalid episode start", job.messages[-1]["text"])
-    
-    @patch('threading.Thread')
+
+    @patch("threading.Thread")
     def test_concurrent_jobs(self, mock_thread):
         """Test that multiple jobs can be created and run concurrently"""
         # Create multiple jobs
@@ -175,13 +189,14 @@ class TestIntegration(unittest.TestCase):
                 f"https://youtube.com/playlist?list=TEST{i}",
                 f"Test Show {i}",
                 "01",
-                "01"
+                "01",
+                playlist_start=None,
             )
             job_ids.append(job_id)
-        
+
         # Verify all jobs were created
         self.assertEqual(len(self.app.jobs), 3)
-        
+
         # Verify that threads were started for each job
         self.assertEqual(mock_thread.call_count, 3)
         for i, job_id in enumerate(job_ids):
@@ -190,5 +205,6 @@ class TestIntegration(unittest.TestCase):
             self.assertEqual(thread_call[1]["args"], (job_id,))
             mock_thread.return_value.start.assert_called()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_playlist_ops.py
+++ b/tests/test_playlist_ops.py
@@ -7,139 +7,152 @@ import subprocess
 from unittest.mock import patch, MagicMock
 from pathlib import Path
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from tubarr.core import YTToJellyfin, DownloadJob
+
 
 class TestPlaylistOperations(unittest.TestCase):
     def setUp(self):
         self.temp_dir = tempfile.mkdtemp()
         self.config = {
-            'output_dir': self.temp_dir,
-            'quality': '720',
-            'use_h265': False,
-            'crf': 28,
-            'ytdlp_path': 'yt-dlp',
-            'cookies': '',
-            'completed_jobs_limit': 3,
-            'web_enabled': False,
-            'web_port': 8000,
-            'web_host': '0.0.0.0',
-            'jellyfin_enabled': False,
-            'jellyfin_tv_path': '',
-            'jellyfin_host': '',
-            'jellyfin_port': '8096',
-            'jellyfin_api_key': '',
-            'clean_filenames': True,
-            'update_checker_enabled': False,
-            'update_checker_interval': 60,
+            "output_dir": self.temp_dir,
+            "quality": "720",
+            "use_h265": False,
+            "crf": 28,
+            "ytdlp_path": "yt-dlp",
+            "cookies": "",
+            "completed_jobs_limit": 3,
+            "web_enabled": False,
+            "web_port": 8000,
+            "web_host": "0.0.0.0",
+            "jellyfin_enabled": False,
+            "jellyfin_tv_path": "",
+            "jellyfin_host": "",
+            "jellyfin_port": "8096",
+            "jellyfin_api_key": "",
+            "clean_filenames": True,
+            "update_checker_enabled": False,
+            "update_checker_interval": 60,
         }
-        with patch.object(YTToJellyfin, '_load_config', return_value=self.config), \
-             patch.object(YTToJellyfin, '_load_playlists', return_value={}):
+        with patch.object(
+            YTToJellyfin, "_load_config", return_value=self.config
+        ), patch.object(YTToJellyfin, "_load_playlists", return_value={}):
             self.app = YTToJellyfin()
-        self.app.playlists_file = os.path.join(self.temp_dir, 'playlists.json')
+        self.app.playlists_file = os.path.join(self.temp_dir, "playlists.json")
 
     def tearDown(self):
         import shutil
+
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
     def test_register_and_list_playlists(self):
-        url = 'https://youtube.com/playlist?list=TEST123'
-        with patch.object(self.app, '_save_playlists') as mock_save:
-            self.app._register_playlist(url, 'Test Show', '01')
+        url = "https://youtube.com/playlist?list=TEST123"
+        with patch.object(self.app, "_save_playlists") as mock_save:
+            self.app._register_playlist(url, "Test Show", "01", None)
             mock_save.assert_called_once()
-        pid = 'TEST123'
+        pid = "TEST123"
         self.assertIn(pid, self.app.playlists)
 
-        folder = self.app.create_folder_structure('Test Show', '01')
-        Path(folder, 'Test Show S01E01.mp4').touch()
-        Path(folder, 'Test Show S01E02.mp4').touch()
-        archive = self.app.playlists[pid]['archive']
+        folder = self.app.create_folder_structure("Test Show", "01")
+        Path(folder, "Test Show S01E01.mp4").touch()
+        Path(folder, "Test Show S01E02.mp4").touch()
+        archive = self.app.playlists[pid]["archive"]
         os.makedirs(os.path.dirname(archive), exist_ok=True)
-        with open(archive, 'w') as f:
-            f.write('id1\n')
-            f.write('id2\n')
-        self.app.update_last_episode('Test Show', '01', 2)
+        with open(archive, "w") as f:
+            f.write("id1\n")
+            f.write("id2\n")
+        self.app.update_last_episode("Test Show", "01", 2)
         playlists = self.app.list_playlists()
         self.assertEqual(len(playlists), 1)
         info = playlists[0]
-        self.assertEqual(info['last_episode'], 2)
-        self.assertEqual(info['downloaded_videos'], 2)
+        self.assertEqual(info["last_episode"], 2)
+        self.assertEqual(info["downloaded_videos"], 2)
 
     def test_get_existing_max_index(self):
-        folder = self.app.create_folder_structure('Show2', '01')
-        Path(folder, 'Show2 S01E01.mp4').touch()
-        Path(folder, 'Show2 S01E03.mp4').touch()
-        max_idx = self.app._get_existing_max_index(folder, '01')
+        folder = self.app.create_folder_structure("Show2", "01")
+        Path(folder, "Show2 S01E01.mp4").touch()
+        Path(folder, "Show2 S01E03.mp4").touch()
+        max_idx = self.app._get_existing_max_index(folder, "01")
         self.assertEqual(max_idx, 3)
 
     def test_disable_and_remove_playlist(self):
-        url = 'https://youtube.com/playlist?list=XYZ'
-        self.app._register_playlist(url, 'Show', '01')
-        pid = 'XYZ'
+        url = "https://youtube.com/playlist?list=XYZ"
+        self.app._register_playlist(url, "Show", "01", None)
+        pid = "XYZ"
         self.assertIn(pid, self.app.playlists)
         self.app.set_playlist_enabled(pid, False)
-        self.assertTrue(self.app.playlists[pid]['disabled'])
+        self.assertTrue(self.app.playlists[pid]["disabled"])
         self.app.set_playlist_enabled(pid, True)
-        self.assertFalse(self.app.playlists[pid]['disabled'])
+        self.assertFalse(self.app.playlists[pid]["disabled"])
         self.app.remove_playlist(pid)
         self.assertNotIn(pid, self.app.playlists)
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_get_playlist_videos_success(self, mock_run):
         mock_run.return_value = MagicMock(
-            stdout=json.dumps({'entries': [{'id': 'a', 'title': 'A'}, {'id': 'b', 'title': 'B'}]}),
+            stdout=json.dumps(
+                {"entries": [{"id": "a", "title": "A"}, {"id": "b", "title": "B"}]}
+            ),
             returncode=0,
         )
-        videos = self.app.get_playlist_videos('https://playlist')
+        videos = self.app.get_playlist_videos("https://playlist")
         self.assertEqual(len(videos), 2)
-        self.assertEqual(videos[0]['title'], 'A')
+        self.assertEqual(videos[0]["title"], "A")
         mock_run.assert_called_once()
 
-    @patch('subprocess.run', side_effect=subprocess.CalledProcessError(1, 'yt-dlp'))
+    @patch("subprocess.run", side_effect=subprocess.CalledProcessError(1, "yt-dlp"))
     def test_get_playlist_videos_failure(self, mock_run):
-        videos = self.app.get_playlist_videos('https://playlist')
+        videos = self.app.get_playlist_videos("https://playlist")
         self.assertEqual(videos, [])
         mock_run.assert_called_once()
 
     def test_process_success_and_failure(self):
-        def fake_create_job(url, show, season, episode_start, start_thread=True):
-            job = DownloadJob('job-1', url, show, season, episode_start)
-            job.status = 'completed'
-            self.app.jobs['job-1'] = job
-            return 'job-1'
+        def fake_create_job(
+            url, show, season, episode_start, playlist_start=None, start_thread=True
+        ):
+            job = DownloadJob("job-1", url, show, season, episode_start)
+            job.status = "completed"
+            self.app.jobs["job-1"] = job
+            return "job-1"
 
-        with patch.object(self.app, 'create_job', side_effect=fake_create_job), \
-             patch.object(self.app, 'cleanup') as mock_cleanup:
-            result = self.app.process('u', 's', '01', 1)
+        with patch.object(
+            self.app, "create_job", side_effect=fake_create_job
+        ), patch.object(self.app, "cleanup") as mock_cleanup:
+            result = self.app.process("u", "s", "01", 1)
             self.assertTrue(result)
             mock_cleanup.assert_called()
 
-        def fake_create_job_fail(url, show, season, episode_start, start_thread=True):
-            job = DownloadJob('job-2', url, show, season, episode_start)
-            job.status = 'failed'
-            self.app.jobs['job-2'] = job
-            return 'job-2'
+        def fake_create_job_fail(
+            url, show, season, episode_start, playlist_start=None, start_thread=True
+        ):
+            job = DownloadJob("job-2", url, show, season, episode_start)
+            job.status = "failed"
+            self.app.jobs["job-2"] = job
+            return "job-2"
 
-        with patch.object(self.app, 'create_job', side_effect=fake_create_job_fail), \
-             patch.object(self.app, 'cleanup'):
-            result = self.app.process('u', 's', '01', 1)
+        with patch.object(
+            self.app, "create_job", side_effect=fake_create_job_fail
+        ), patch.object(self.app, "cleanup"):
+            result = self.app.process("u", "s", "01", 1)
             self.assertFalse(result)
 
     def test_start_update_checker_thread(self):
         """start_update_checker should create and start a daemon thread"""
         temp_dir = tempfile.mkdtemp()
         config = self.config.copy()
-        config.update({
-            'output_dir': temp_dir,
-            'update_checker_enabled': True,
-            'update_checker_interval': 2,
-        })
+        config.update(
+            {
+                "output_dir": temp_dir,
+                "update_checker_enabled": True,
+                "update_checker_interval": 2,
+            }
+        )
         playlists = {
-            'PID': {
-                'url': 'https://yt/playlist',
-                'show_name': 'Show',
-                'season_num': '01'
+            "PID": {
+                "url": "https://yt/playlist",
+                "show_name": "Show",
+                "season_num": "01",
             }
         }
         threads = []
@@ -161,11 +174,17 @@ class TestPlaylistOperations(unittest.TestCase):
         def fake_sleep(duration):
             raise StopIteration
 
-        with patch.object(YTToJellyfin, '_load_config', return_value=config), \
-             patch.object(YTToJellyfin, '_load_playlists', return_value=playlists), \
-             patch.object(YTToJellyfin, 'check_playlist_updates') as mock_check, \
-             patch('threading.Thread', side_effect=fake_thread) as mock_thread, \
-             patch('time.sleep', side_effect=fake_sleep) as mock_sleep:
+        with patch.object(
+            YTToJellyfin, "_load_config", return_value=config
+        ), patch.object(
+            YTToJellyfin, "_load_playlists", return_value=playlists
+        ), patch.object(
+            YTToJellyfin, "check_playlist_updates"
+        ) as mock_check, patch(
+            "threading.Thread", side_effect=fake_thread
+        ) as mock_thread, patch(
+            "time.sleep", side_effect=fake_sleep
+        ) as mock_sleep:
             ytj = YTToJellyfin()
 
         self.assertEqual(len(threads), 1)
@@ -174,7 +193,10 @@ class TestPlaylistOperations(unittest.TestCase):
         self.assertTrue(thread.daemon)
         thread.start.assert_called_once()
         mock_check.assert_called_once()
-        mock_sleep.assert_called_once_with(max(1, config['update_checker_interval']) * 60)
+        mock_sleep.assert_called_once_with(
+            max(1, config["update_checker_interval"]) * 60
+        )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tubarr/web.py
+++ b/tubarr/web.py
@@ -11,6 +11,7 @@ from flask import (
 import os
 
 from .core import logger, YTToJellyfin
+
 # Create Flask application for web interface
 # Determine the repository root so the web assets can be located correctly
 _BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
@@ -61,6 +62,7 @@ def jobs():
                 show_name,
                 season_num,
                 episode_start,
+                playlist_start=None,
                 track_playlist=track_playlist,
             )
         return jsonify({"job_id": job_id})
@@ -222,4 +224,4 @@ def config():
         return jsonify(safe_config)
 
 
-__all__ = ['app', 'ytj']
+__all__ = ["app", "ytj"]


### PR DESCRIPTION
## Summary
- add start index tracking when registering playlists
- skip videos before the stored index during update checks
- update playlist index after successful jobs
- seed archive for skipped videos when playlist is first added
- document new playlist start behavior
- adjust existing tests and add a new case

## Testing
- `flake8 .` *(fails: command not found)*
- `python run_tests.py` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6845cbaa566883238eca1b396b351302