### PR TITLE
Fix Python 3.8 union types

### DIFF
--- a/tubarr/core.py
+++ b/tubarr/core.py
@@ -85,7 +85,7 @@ class YTToJellyfin:
         return _is_playlist_url(url)
 
     def _register_playlist(
-        self, url: str, show_name: str, season_num: str, start_index: int | None = None
+        self, url: str, show_name: str, season_num: str, start_index: Optional[int] = None
     ) -> bool:
         return _register_playlist(
             self.playlists,

--- a/tubarr/playlist.py
+++ b/tubarr/playlist.py
@@ -5,7 +5,7 @@ import subprocess
 import threading
 import time
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from .config import logger
 from .utils import sanitize_name
@@ -49,7 +49,7 @@ def _register_playlist(
     url: str,
     show_name: str,
     season_num: str,
-    start_index: int | None = None,
+    start_index: Optional[int] = None,
 ) -> bool:
     """Add a playlist to the tracking file if not already present."""
     pid = _get_playlist_id(url)


### PR DESCRIPTION
## Summary
- use Optional syntax compatible with Python 3.8

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6845e67685108323aad4622e2f2bd4d2