### PR TITLE
Fix ffmpeg poster generation filter

### DIFF
--- a/tests/test_media_processing.py
+++ b/tests/test_media_processing.py
@@ -98,6 +98,8 @@ class TestMediaProcessing(unittest.TestCase):
         self.assertEqual(mock_popen.call_args_list[1][0][0][0], 'convert')
         ffmpeg_calls = [c for c in mock_run.call_args_list if c[0][0][0] == 'ffmpeg']
         self.assertTrue(ffmpeg_calls)
+        expected_filter = 'select=not(mod(n\\,1000)),scale=640:360'
+        self.assertIn(expected_filter, ffmpeg_calls[0][0])
         self.job.update.assert_any_call(status='generating_artwork', message='Generating thumbnails and artwork')
         self.job.update.assert_any_call(progress=100, message='Created season artwork')
 

--- a/tubarr/media.py
+++ b/tubarr/media.py
@@ -353,7 +353,17 @@ def generate_artwork(app, folder: str, show_name: str, season_num: str, job_id: 
         temp_posters = []
         for i, episode in enumerate(episodes[:1]):
             poster_file = os.path.join(app.temp_dir, f"tmp_poster_{i:03d}.jpg")
-            subprocess.run(["ffmpeg", "-i", str(episode), "-vf", "select='not(mod(n,1000))',scale=640:360", "-vframes", "3", poster_file], check=True, capture_output=True)
+            filter_str = "select=not(mod(n\,1000)),scale=640:360"
+            subprocess.run([
+                "ffmpeg",
+                "-i",
+                str(episode),
+                "-vf",
+                filter_str,
+                "-vframes",
+                "3",
+                poster_file,
+            ], check=True, capture_output=True)
             temp_posters.append(poster_file)
         if temp_posters:
             poster_path = os.path.join(show_folder, "poster.jpg")


### PR DESCRIPTION
## Summary
- fix ffmpeg filter string when generating artwork
- verify filter string in media processing tests

## Testing
- `python run_tests.py`
- `flake8 .` *(fails: E302, E501, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6846c4832b288323abcb7ea97495d5ee