### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,15 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           generate_release_notes: true
           draft: false


### PR DESCRIPTION
## Summary
- grant contents:write permission to release workflow
- pass GITHUB_TOKEN to softprops/action-gh-release

## Testing
- `python run_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_6846d7189cc083238b08e7d5ad4df5ad