### PR TITLE
Improve yt-dlp path detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ You can configure it by editing the `docker-compose.yml` file and the `config/co
 | USE_H265 | Enable H.265 conversion | true |
 | CRF | Compression quality (lower = better quality, larger files) | 28 |
 | CLEAN_FILENAMES | Replace underscores with spaces in filenames | true |
-| YTDLP_PATH | Path to yt-dlp executable | yt-dlp |
+| YTDLP_PATH | Path to yt-dlp executable (optional) | yt-dlp |
 | COOKIES_PATH | Path to cookies file (optional) | |
 | WEB_ENABLED | Enable the web interface | true |
 | WEB_PORT | Port for the web interface | 8000 |
@@ -164,6 +164,10 @@ You can configure it by editing the `docker-compose.yml` file and the `config/co
 | JELLYFIN_HOST | Jellyfin server hostname/IP | |
 | JELLYFIN_PORT | Jellyfin server port | 8096 |
 | JELLYFIN_API_KEY | Jellyfin API key for triggering library scan (optional) | |
+
+If `YTDLP_PATH` is not provided, Tubarr will search common locations
+(`/usr/local/bin/yt-dlp`, `/usr/bin/yt-dlp`) and fall back to simply
+`yt-dlp` in the current `PATH`.
 
 ### Using a Cookies File
 

--- a/config/config.yml
+++ b/config/config.yml
@@ -10,7 +10,7 @@ media:
 
 # Optional Settings
 cookies_path: ./config/cookies.txt  # Optional cookies file for authenticated content
-ytdlp_path: /home/marc/Documents/yt-dlp/yt-dlp  # Path to your existing yt-dlp
+ytdlp_path: yt-dlp  # Executable path or leave for auto-detect
 
 # Web Interface Settings
 web:

--- a/tubarr/config.py
+++ b/tubarr/config.py
@@ -43,12 +43,7 @@ def _load_config() -> Dict:
     if os.path.exists(local_ytdlp) and os.access(local_ytdlp, os.X_OK):
         ytdlp_default = local_ytdlp
     else:
-        specific_paths = [
-            "/home/marc/Documents/yt-dlp/yt-dlp",
-            "/usr/local/bin/yt-dlp",
-            "/usr/bin/yt-dlp",
-        ]
-        for path in specific_paths:
+        for path in ["/usr/local/bin/yt-dlp", "/usr/bin/yt-dlp"]:
             if os.path.exists(path) and os.access(path, os.X_OK):
                 ytdlp_default = path
                 break


### PR DESCRIPTION
## Summary
- search for yt-dlp in `/usr/local/bin` and `/usr/bin` by default
- update sample config and README for new search order

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d76f408483238279d475dad8ba02