### PR TITLE
Add packaging support

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include web *
+recursive-include config *.yml

--- a/README.md
+++ b/README.md
@@ -204,6 +204,21 @@ If you prefer to manage the files manually:
 3. Set the metadata provider to "Local metadata only" to use the generated NFO files
 4. Scan the library, and your shows will appear with proper metadata and artwork
 
+## Packaging and Installation
+
+To build Tubarr as a Python package, install the build tool and run:
+
+```bash
+python -m pip install build
+python -m build
+```
+
+This creates a wheel file in the `dist/` directory. Install it with:
+
+```bash
+pip install dist/tubarr-*.whl
+```
+
 ## Testing
 
 Tubarr includes a comprehensive test suite to verify functionality.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tubarr"
+version = "0.1.0"
+description = "Download YouTube playlists and integrate with Jellyfin/Kodi."
+readme = "README.md"
+requires-python = ">=3.8"
+authors = [{name = "Tubarr"}]
+license = {file = "LICENSE"}
+dependencies = [
+    "requests>=2.28.0",
+    "pyyaml>=6.0",
+    "flask>=2.2.0",
+    "gunicorn>=20.1.0",
+    "waitress>=2.1.2",
+    "pydantic>=2.1",
+]
+
+[project.scripts]
+tubarr = "tubarr.cli:main"
+
+[tool.setuptools]
+packages = ["tubarr"]
+py-modules = ["app"]
+include-package-data = true
+
+[tool.setuptools.package-data]
+"tubarr" = []
+
+[tool.setuptools.data-files]
+"web/templates" = ["web/templates/*.html"]
+"web/static" = ["web/static/*"]
+"config" = ["config/*.yml"]


### PR DESCRIPTION
## Summary
- add pyproject build metadata
- include static templates via MANIFEST
- document building and installing from wheel

## Testing
- `pip install -r requirements.txt`
- `python run_tests.py --type basic`
- `python -m build`


------
https://chatgpt.com/codex/tasks/task_e_6846d77bddc08323b9529043b440ca30