### PR TITLE
Implement sequential job queue processing

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -195,13 +195,15 @@ class TestIntegration(unittest.TestCase):
         # Verify all jobs were created
         self.assertEqual(len(self.app.jobs), 3)
 
-        # Verify that threads were started for each job
-        self.assertEqual(mock_thread.call_count, 3)
-        for i, job_id in enumerate(job_ids):
-            thread_call = mock_thread.call_args_list[i]
-            self.assertEqual(thread_call[1]["target"], self.app.process_job)
-            self.assertEqual(thread_call[1]["args"], (job_id,))
-            mock_thread.return_value.start.assert_called()
+        # Only the first job should start immediately
+        self.assertEqual(mock_thread.call_count, 1)
+        thread_call = mock_thread.call_args_list[0]
+        self.assertEqual(thread_call[1]["target"], self.app.process_job)
+        self.assertEqual(thread_call[1]["args"], (job_ids[0],))
+        mock_thread.return_value.start.assert_called_once()
+
+        # Remaining jobs should be queued
+        self.assertEqual(self.app.job_queue, job_ids[1:])
 
 
 if __name__ == "__main__":

--- a/tubarr/jobs.py
+++ b/tubarr/jobs.py
@@ -179,8 +179,16 @@ def create_job(
             old_job = completed_jobs.pop(0)
             del app.jobs[old_job.job_id]
 
-    if start_thread:
-        threading.Thread(target=app.process_job, args=(job_id,)).start()
+        if app.active_job_id is None:
+            app.active_job_id = job_id
+            if start_thread:
+                threading.Thread(target=app.process_job, args=(job_id,)).start()
+        else:
+            app.job_queue.append(job_id)
+            job.update(message="Job queued")
+
+    # If start_thread is False and there is no active job, the caller is
+    # expected to process the job manually.
 
     return job_id
 


### PR DESCRIPTION
## Summary
- ensure only one playlist job runs at a time
- add queue management to `YTToJellyfin` and job creation
- extend process completion logic to start next queued job
- update integration test for new queued behaviour

## Testing
- `python run_tests.py --type all`

------
https://chatgpt.com/codex/tasks/task_e_6846e6c8a84c832395938227c9d7a581