### PR TITLE
Add movie workflow support

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -254,6 +254,18 @@ class TestAPIEndpoints(unittest.TestCase):
         self.assertFalse(ytj.config["use_h265"])
         self.assertEqual(ytj.config["cookies"], "/cookies.txt")
 
+    @patch("app.YTToJellyfin.create_movie_job")
+    def test_create_movie_job(self, mock_create):
+        mock_create.return_value = "m1"
+        response = self.client.post(
+            "/movies",
+            json={"video_url": "https://youtube.com/watch?v=abc", "movie_name": "My Movie"},
+        )
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertEqual(data["job_id"], "m1")
+        mock_create.assert_called_once_with("https://youtube.com/watch?v=abc", "My Movie")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_movie.py
+++ b/tests/test_movie.py
@@ -1,0 +1,95 @@
+import os
+import tempfile
+import shutil
+import json
+import unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock, call
+
+from tubarr.core import YTToJellyfin, DownloadJob
+from tubarr import jellyfin as jellyfin_mod
+
+
+class TestMovieWorkflow(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.jellyfin_dir = tempfile.mkdtemp()
+        self.config = {
+            "output_dir": self.temp_dir,
+            "quality": "720",
+            "use_h265": False,
+            "crf": 28,
+            "ytdlp_path": "yt-dlp",
+            "cookies": "",
+            "completed_jobs_limit": 3,
+            "max_concurrent_jobs": 1,
+            "web_enabled": False,
+            "web_port": 8000,
+            "web_host": "0.0.0.0",
+            "jellyfin_enabled": True,
+            "jellyfin_tv_path": "",
+            "jellyfin_movie_path": self.jellyfin_dir,
+            "jellyfin_host": "localhost",
+            "jellyfin_port": "8096",
+            "jellyfin_api_key": "",
+            "clean_filenames": True,
+            "update_checker_enabled": False,
+            "update_checker_interval": 60,
+        }
+        with patch.object(YTToJellyfin, "_load_config", return_value=self.config), patch.object(YTToJellyfin, "_load_playlists", return_value={}):
+            self.app = YTToJellyfin()
+        self.job = DownloadJob("job1", "url", "", "", "", media_type="movie", movie_name="Test Movie")
+        self.app.jobs["job1"] = self.job
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+        shutil.rmtree(self.jellyfin_dir, ignore_errors=True)
+
+    def test_create_movie_job(self):
+        with patch("threading.Thread") as mock_thread:
+            job_id = self.app.create_movie_job("https://youtube.com/watch?v=abc", "My Movie")
+            self.assertIn(job_id, self.app.jobs)
+            job = self.app.jobs[job_id]
+            self.assertEqual(job.media_type, "movie")
+            self.assertEqual(job.movie_name, "My Movie")
+            mock_thread.assert_called_once()
+            mock_thread.return_value.start.assert_called_once()
+
+    def test_process_movie_metadata_creates_nfo(self):
+        folder = Path(self.temp_dir) / "Test Movie"
+        folder.mkdir(parents=True, exist_ok=True)
+        (folder / "video.mp4").write_text("data")
+        info = {"description": "Desc", "upload_date": "20220101", "id": "abc"}
+        with open(folder / "video.info.json", "w") as f:
+            json.dump(info, f)
+        with patch("subprocess.run") as mock_run:
+            self.app.process_movie_metadata(str(folder), "Test Movie", "job1")
+        nfo = folder / "movie.nfo"
+        self.assertTrue(nfo.exists())
+        with open(nfo) as f:
+            content = f.read()
+        self.assertIn("<movie>", content)
+        renamed = folder / "Test Movie (2022) [abc].mp4"
+        self.assertTrue(renamed.exists())
+        self.assertFalse((folder / "video.mp4").exists())
+
+    def test_copy_movie_to_jellyfin(self):
+        src_folder = Path(self.temp_dir) / "Test Movie"
+        src_folder.mkdir(parents=True, exist_ok=True)
+        (src_folder / "Test Movie.mp4").touch()
+        (src_folder / "movie.nfo").touch()
+        dest_folder = Path(self.jellyfin_dir) / "Test Movie"
+        with patch("os.path.exists", side_effect=lambda p: False if str(p).startswith(str(dest_folder)) else os.path.exists(p)), patch("os.makedirs") as mock_mkdir, patch("shutil.copy2") as mock_copy2, patch.object(self.app, "trigger_jellyfin_scan") as mock_scan:
+            jellyfin_mod.copy_movie_to_jellyfin(self.app, "Test Movie", "job1")
+            mock_mkdir.assert_called_with(dest_folder, exist_ok=True)
+            expected_calls = [
+                call(src_folder / "Test Movie.mp4", dest_folder / "Test Movie.mp4"),
+                call(src_folder / "movie.nfo", dest_folder / "movie.nfo"),
+            ]
+            for c in expected_calls:
+                self.assertIn(c, mock_copy2.call_args_list)
+            mock_scan.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tubarr/config.py
+++ b/tubarr/config.py
@@ -23,6 +23,7 @@ class ConfigModel(BaseModel):
     update_checker_interval: int = Field(..., ge=1)
     jellyfin_enabled: bool = False
     jellyfin_tv_path: str = ""
+    jellyfin_movie_path: str = ""
     jellyfin_host: str = ""
     jellyfin_port: int = Field(8096, ge=1, le=65535)
     jellyfin_api_key: str = ""
@@ -73,6 +74,7 @@ def _load_config() -> Dict:
         "jellyfin_enabled": os.environ.get("JELLYFIN_ENABLED", "false").lower()
         == "true",
         "jellyfin_tv_path": os.environ.get("JELLYFIN_TV_PATH", ""),
+        "jellyfin_movie_path": os.environ.get("JELLYFIN_MOVIE_PATH", ""),
         "jellyfin_host": os.environ.get("JELLYFIN_HOST", ""),
         "jellyfin_port": os.environ.get("JELLYFIN_PORT", "8096"),
         "jellyfin_api_key": os.environ.get("JELLYFIN_API_KEY", ""),
@@ -141,6 +143,8 @@ def _load_config() -> Dict:
                             config["jellyfin_enabled"] = value
                         elif key == "tv_path":
                             config["jellyfin_tv_path"] = value
+                        elif key == "movie_path":
+                            config["jellyfin_movie_path"] = value
                         elif key == "host":
                             config["jellyfin_host"] = value
                         elif key == "port":

--- a/tubarr/jobs.py
+++ b/tubarr/jobs.py
@@ -19,6 +19,8 @@ class DownloadJob:
         season_num,
         episode_start,
         playlist_start=None,
+        media_type="tv",
+        movie_name="",
     ):
         self.job_id = job_id
         self.playlist_url = playlist_url
@@ -26,6 +28,8 @@ class DownloadJob:
         self.season_num = season_num
         self.episode_start = episode_start
         self.playlist_start = playlist_start
+        self.media_type = media_type
+        self.movie_name = movie_name
         self.status = "queued"
         self.progress = 0
         self.messages = []
@@ -103,6 +107,8 @@ class DownloadJob:
             "season_num": self.season_num,
             "episode_start": self.episode_start,
             "playlist_start": self.playlist_start,
+            "media_type": self.media_type,
+            "movie_name": self.movie_name,
             "status": self.status,
             "progress": self.progress,
             "messages": messages,

--- a/tubarr/web.py
+++ b/tubarr/web.py
@@ -68,6 +68,19 @@ def jobs():
         return jsonify(ytj.get_jobs())
 
 
+@app.route("/movies", methods=["GET", "POST"])
+def movies():
+    if request.method == "POST":
+        video_url = request.form.get("video_url") or (request.json or {}).get("video_url")
+        movie_name = request.form.get("movie_name") or (request.json or {}).get("movie_name")
+        if not video_url or not movie_name:
+            return jsonify({"error": "Missing required parameters"}), 400
+        job_id = ytj.create_movie_job(video_url, movie_name)
+        return jsonify({"job_id": job_id})
+    else:
+        return jsonify(ytj.list_movies())
+
+
 @app.route("/jobs/<job_id>", methods=["GET", "DELETE"])
 def job_detail(job_id):
     """Get or modify a specific job."""
@@ -150,6 +163,7 @@ def config():
                 "max_concurrent_jobs",
                 "jellyfin_enabled",
                 "jellyfin_tv_path",
+                "jellyfin_movie_path",
                 "jellyfin_host",
                 "jellyfin_port",
                 "jellyfin_api_key",


### PR DESCRIPTION
## Summary
- configure Jellyfin movie path
- add movie-related fields to DownloadJob
- support movie folders and metadata processing
- enable copying movies to Jellyfin
- expose movie job API endpoints
- implement movie workflow unit tests

## Testing
- `pip install -e .`
- `pip install selenium`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846ecdaf75c8323a9e0cf56c69f5824