### PR TITLE
Add movie artwork generation step

### DIFF
--- a/tubarr/core.py
+++ b/tubarr/core.py
@@ -301,6 +301,9 @@ class YTToJellyfin:
             self.process_movie_metadata(folder, job.movie_name, job_id)
             if job.status == "cancelled":
                 return
+            self.generate_movie_artwork(folder, job_id)
+            if job.status == "cancelled":
+                return
             if self.config.get("jellyfin_enabled", False) and self.config.get("jellyfin_movie_path"):
                 self.copy_movie_to_jellyfin(job.movie_name, job_id)
             job.update(status="completed", progress=100, message="Job completed successfully")


### PR DESCRIPTION
## Summary
- generate movie artwork after processing movie metadata
- test full movie job workflow

## Testing
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6846f795f0d8832398ed76ba877f0c7b