### PR TITLE
Add Total Movies card to dashboard

### DIFF
--- a/web/static/script.js
+++ b/web/static/script.js
@@ -368,6 +368,16 @@ function loadDashboard() {
         .catch(error => {
             console.error('Error fetching media:', error);
         });
+
+    // Load movie data
+    fetch('/movies')
+        .then(response => response.json())
+        .then(movies => {
+            updateMovieStats(movies);
+        })
+        .catch(error => {
+            console.error('Error fetching movies:', error);
+        });
 }
 
 function loadJobs() {
@@ -1035,6 +1045,11 @@ function updateMediaStats(media) {
     document.getElementById('total-shows').textContent = totalShows;
     document.getElementById('total-episodes').textContent = totalEpisodes;
     document.getElementById('storage-used').textContent = formatFileSize(totalSize);
+}
+
+function updateMovieStats(movies) {
+    const totalMovies = movies.length;
+    document.getElementById('total-movies').textContent = totalMovies;
 }
 
 function updateRecentJobs(jobs) {

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -182,3 +182,10 @@ main {
         margin-left: 0 !important;
     }
 }
+
+@media (min-width: 1200px) {
+    .dashboard-col {
+        flex: 0 0 20%;
+        max-width: 20%;
+    }
+}

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -72,7 +72,7 @@
                     </div>
                     
                     <div class="row">
-                        <div class="col-xl-3 col-md-6 mb-4">
+                        <div class="dashboard-col col-md-6 mb-4">
                             <div class="card border-left-primary shadow h-100 py-2">
                                 <div class="card-body">
                                     <div class="row no-gutters align-items-center">
@@ -89,7 +89,7 @@
                             </div>
                         </div>
                         
-                        <div class="col-xl-3 col-md-6 mb-4">
+                        <div class="dashboard-col col-md-6 mb-4">
                             <div class="card border-left-success shadow h-100 py-2">
                                 <div class="card-body">
                                     <div class="row no-gutters align-items-center">
@@ -105,8 +105,25 @@
                                 </div>
                             </div>
                         </div>
+
+                        <div class="dashboard-col col-md-6 mb-4">
+                            <div class="card border-left-secondary shadow h-100 py-2">
+                                <div class="card-body">
+                                    <div class="row no-gutters align-items-center">
+                                        <div class="col mr-2">
+                                            <div class="text-xs font-weight-bold text-secondary text-uppercase mb-1">
+                                                Total Movies</div>
+                                            <div class="h5 mb-0 font-weight-bold text-gray-800" id="total-movies">0</div>
+                                        </div>
+                                        <div class="col-auto">
+                                            <i class="bi bi-collection-play fs-2 text-gray-300"></i>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                         
-                        <div class="col-xl-3 col-md-6 mb-4">
+                        <div class="dashboard-col col-md-6 mb-4">
                             <div class="card border-left-info shadow h-100 py-2">
                                 <div class="card-body">
                                     <div class="row no-gutters align-items-center">
@@ -123,7 +140,7 @@
                             </div>
                         </div>
                         
-                        <div class="col-xl-3 col-md-6 mb-4">
+                        <div class="dashboard-col col-md-6 mb-4">
                             <div class="card border-left-warning shadow h-100 py-2">
                                 <div class="card-body">
                                     <div class="row no-gutters align-items-center">


### PR DESCRIPTION
## Summary
- add a **Total Movies** dashboard card
- compute movie stats in JS and fetch `/movies`
- narrow dashboard cards so all five fit on one row

## Testing
- `python run_tests.py` *(fails: ModuleNotFoundError: yaml)*

------
https://chatgpt.com/codex/tasks/task_e_6847059c2f9083238b8cff1d4d681565