### PR TITLE
Add movie support to media library view

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -88,6 +88,15 @@ main {
     box-shadow: 0 0.5rem 2rem 0 rgba(58, 59, 69, 0.3);
 }
 
+.movie-card {
+    transition: all 0.3s ease;
+}
+
+.movie-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 0.5rem 2rem 0 rgba(58, 59, 69, 0.3);
+}
+
 .season-card {
     cursor: pointer;
 }

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -522,7 +522,13 @@
                         </button>
                     </div>
                     
-                    <div id="media-container">
+                    <h3 class="mt-4">TV Shows</h3>
+                    <div id="media-tv-container">
+                        <!-- Will be populated by JavaScript -->
+                    </div>
+
+                    <h3 class="mt-4">Movies</h3>
+                    <div id="media-movie-container">
                         <!-- Will be populated by JavaScript -->
                     </div>
                 </section>


### PR DESCRIPTION
## Summary
- split media library into TV Shows and Movies
- fetch movies list via `/movies` and render movie cards
- refactor `loadMedia()` and `displayMediaLibrary()` for both lists
- add `.movie-card` styles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_68471d4594b08323981df1619e041561