### PR TITLE
Add movie job tables

### DIFF
--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -384,6 +384,31 @@
                         </div>
                     </div>
 
+                    <div class="card shadow mb-4">
+                        <div class="card-header py-3 d-flex flex-row align-items-center justify-content-between">
+                            <h6 class="m-0 font-weight-bold">Movie History</h6>
+                        </div>
+                        <div class="card-body">
+                            <div class="table-responsive">
+                                <table class="table table-hover" id="movie-history-table">
+                                    <thead>
+                                        <tr>
+                                            <th>ID</th>
+                                            <th>Movie</th>
+                                            <th>Status</th>
+                                            <th>Progress</th>
+                                            <th>Created</th>
+                                            <th>Actions</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <!-- Will be populated by JavaScript -->
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+
                 </section>
 
                 <!-- Jobs Section -->
@@ -417,7 +442,32 @@
                             </div>
                         </div>
                     </div>
-                    
+
+                    <div class="card shadow mb-4">
+                        <div class="card-header py-3 d-flex flex-row align-items-center justify-content-between">
+                            <h6 class="m-0 font-weight-bold">Movie Jobs</h6>
+                        </div>
+                        <div class="card-body">
+                            <div class="table-responsive">
+                                <table class="table table-hover" id="movie-jobs-table">
+                                    <thead>
+                                        <tr>
+                                            <th>ID</th>
+                                            <th>Movie</th>
+                                            <th>Status</th>
+                                            <th>Progress</th>
+                                            <th>Created</th>
+                                            <th>Actions</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <!-- Will be populated by JavaScript -->
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+
                 </section>
 
                 <!-- Playlist Start Modal -->


### PR DESCRIPTION
## Summary
- add movie job and movie history tables to HTML
- filter jobs/history by media type in script
- display movie jobs with new helper functions

## Testing
- `python run_tests.py --type basic`
- `python run_tests.py --type api`
- `python run_tests.py --type job`
- `python run_tests.py --type integration`
- `python run_tests.py --type jellyfin`


------
https://chatgpt.com/codex/tasks/task_e_68471ea67774832383559d9f33eaee22