### PR TITLE
Add movie name display in job modal

### DIFF
--- a/web/static/script.js
+++ b/web/static/script.js
@@ -831,6 +831,24 @@ function updateJobDetailModal(job) {
     document.getElementById('detail-show-name').textContent = job.show_name;
     document.getElementById('detail-season').textContent = job.season_num;
     document.getElementById('detail-episode-start').textContent = job.episode_start;
+    document.getElementById('detail-movie-name').textContent = job.movie_name || '';
+
+    const movieField = document.getElementById('detail-movie-field');
+    const showField = document.getElementById('detail-show-name').parentElement;
+    const seasonField = document.getElementById('detail-season').parentElement;
+    const episodeField = document.getElementById('detail-episode-start').parentElement;
+
+    if (job.media_type === 'movie') {
+        movieField.style.display = 'block';
+        showField.style.display = 'none';
+        seasonField.style.display = 'none';
+        episodeField.style.display = 'none';
+    } else {
+        movieField.style.display = 'none';
+        showField.style.display = 'block';
+        seasonField.style.display = 'block';
+        episodeField.style.display = 'block';
+    }
     
     const statusBadge = document.getElementById('detail-status');
     statusBadge.textContent = job.status;

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -140,6 +140,11 @@ main {
     font-size: 0.8rem;
 }
 
+/* Movie name hidden by default */
+#detail-movie-field {
+    display: none;
+}
+
 /* Media cards styling */
 .show-poster-container {
     position: relative;

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -502,6 +502,7 @@
                                 <p><strong>Show:</strong> <span id="detail-show-name"></span></p>
                                 <p><strong>Season:</strong> <span id="detail-season"></span></p>
                                 <p><strong>Episode Start:</strong> <span id="detail-episode-start"></span></p>
+                                <p id="detail-movie-field"><strong>Movie:</strong> <span id="detail-movie-name"></span></p>
                             </div>
                             <div class="col-md-6">
                                 <p><strong>Status:</strong> <span id="detail-status" class="badge"></span></p>


### PR DESCRIPTION
## Summary
- show movie name in job details modal
- hide movie fields or TV fields depending on media type

## Testing
- `python run_tests.py` *(fails: ModuleNotFoundError)*
- `flake8 .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68472017512c832395cdd818db2ee50a