### PR TITLE
Fix movie listing when files renamed

### DIFF
--- a/tests/test_movie.py
+++ b/tests/test_movie.py
@@ -242,6 +242,23 @@ class TestMovieWorkflow(unittest.TestCase):
             message="No movie file found for artwork generation"
         )
 
+    def test_list_movies_detects_renamed_movie(self):
+        folder = Path(self.temp_dir) / "My Movie"
+        folder.mkdir(parents=True, exist_ok=True)
+        movie_file = folder / "My Movie (2023) [abc].mp4"
+        movie_file.write_text("data")
+        poster = folder / "poster.jpg"
+        poster.touch()
+
+        movies = self.app.list_movies()
+
+        self.assertEqual(len(movies), 1)
+        self.assertEqual(movies[0]["name"], "My Movie")
+        self.assertEqual(Path(movies[0]["path"]).name, movie_file.name)
+        self.assertEqual(
+            movies[0]["poster"], os.path.relpath(poster, self.temp_dir)
+        )
+
     @patch("app.YTToJellyfin.copy_movie_to_jellyfin")
     @patch("app.YTToJellyfin.generate_movie_artwork")
     @patch("app.YTToJellyfin.process_movie_metadata")

--- a/tubarr/media.py
+++ b/tubarr/media.py
@@ -957,12 +957,19 @@ def list_movies(app) -> List[Dict]:
         ):
             continue
         movie_file = None
-        for ext in ["mp4"]:
+        for ext in ["mp4", "mkv", "webm"]:
             candidate = movie_dir / f"{movie_dir.name}.{ext}"
             if candidate.exists():
                 movie_file = candidate
                 break
+        if not movie_file:
+            for ext in ["mp4", "mkv", "webm"]:
+                files = list(movie_dir.glob(f"*.{ext}"))
+                if files:
+                    movie_file = files[0]
+                    break
         if movie_file:
+            poster_file = movie_dir / "poster.jpg"
             movies.append(
                 {
                     "name": movie_dir.name,
@@ -971,6 +978,9 @@ def list_movies(app) -> List[Dict]:
                     "modified": datetime.fromtimestamp(
                         movie_file.stat().st_mtime
                     ).strftime("%Y-%m-%d %H:%M:%S"),
+                    "poster": os.path.relpath(poster_file, output_dir)
+                    if poster_file.exists()
+                    else None,
                 }
             )
     return movies


### PR DESCRIPTION
## Summary
- handle movie files that don't exactly match the directory name
- expose movie poster paths in listing
- test movie listing with renamed file

## Testing
- `python run_tests.py --type basic`
- `python run_tests.py`
- `pytest tests/test_movie.py::TestMovieWorkflow::test_list_movies_detects_renamed_movie -q`


------
https://chatgpt.com/codex/tasks/task_e_68473490ebc08323be32503d361f419f