### PR TITLE
Add H.265 conversion for movie downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ curl -X POST http://localhost:8000/movies \
 
 Open the **New Movie Download** section, enter the video or playlist URL and the
 movie name, then click **Start Download**.
+Movie files will be converted to H.265 if the feature is enabled, just like TV downloads.
 
 ### Managing Playlists and Updates
 

--- a/tests/test_additional.py
+++ b/tests/test_additional.py
@@ -98,6 +98,14 @@ class TestConversionWorkflow(unittest.TestCase):
             "H.265 conversion disabled", job.update.call_args.kwargs.get("message")
         )
 
+    def test_convert_movie_file_disabled(self):
+        self.yt.convert_movie_file(self.temp_dir, "job")
+        job = self.yt.jobs["job"]
+        job.update.assert_called()
+        self.assertIn(
+            "H.265 conversion disabled", job.update.call_args.kwargs.get("message")
+        )
+
 
 class TestAPIExtensions(unittest.TestCase):
     def setUp(self):

--- a/tests/test_movie.py
+++ b/tests/test_movie.py
@@ -261,6 +261,7 @@ class TestMovieWorkflow(unittest.TestCase):
 
     @patch("app.YTToJellyfin.copy_movie_to_jellyfin")
     @patch("app.YTToJellyfin.generate_movie_artwork")
+    @patch("app.YTToJellyfin.convert_movie_file")
     @patch("app.YTToJellyfin.process_movie_metadata")
     @patch("app.YTToJellyfin.download_playlist")
     @patch("app.YTToJellyfin.check_dependencies", return_value=True)
@@ -271,6 +272,7 @@ class TestMovieWorkflow(unittest.TestCase):
         mock_check,
         mock_download,
         mock_metadata,
+        mock_convert,
         mock_artwork,
         mock_copy,
     ):
@@ -294,6 +296,7 @@ class TestMovieWorkflow(unittest.TestCase):
             job_id,
         )
         mock_metadata.assert_called_once()
+        mock_convert.assert_called_once()
         mock_artwork.assert_called_once()
         mock_copy.assert_called_once_with("Test Movie", job_id)
 
@@ -329,6 +332,7 @@ class TestMovieWorkflow(unittest.TestCase):
                 side_effect=fake_download,
             ),
             patch.object(self.app, "process_movie_metadata"),
+            patch.object(self.app, "convert_movie_file"),
             patch.object(self.app, "copy_movie_to_jellyfin"),
             patch.object(
                 self.app,

--- a/tubarr/core.py
+++ b/tubarr/core.py
@@ -29,6 +29,7 @@ from .media import (
     download_playlist,
     process_metadata,
     process_movie_metadata,
+    convert_movie_file,
     convert_video_files,
     generate_artwork,
     generate_movie_artwork,
@@ -304,6 +305,9 @@ class YTToJellyfin:
             self.process_movie_metadata(folder, job.movie_name, job_id)
             if job.status == "cancelled":
                 return
+            self.convert_movie_file(folder, job_id)
+            if job.status == "cancelled":
+                return
             self.generate_movie_artwork(folder, job_id)
             if job.status == "cancelled":
                 return
@@ -374,6 +378,9 @@ class YTToJellyfin:
         self, folder: str, movie_name: str, job_id: str, json_index: int = 0
     ) -> None:
         process_movie_metadata(self, folder, movie_name, job_id, json_index)
+
+    def convert_movie_file(self, folder: str, job_id: str) -> None:
+        convert_movie_file(self, folder, job_id)
 
     def convert_video_files(self, folder: str, season_num: str, job_id: str) -> None:
         convert_video_files(self, folder, season_num, job_id)


### PR DESCRIPTION
## Summary
- convert downloaded movies to H.265 if enabled
- expose `convert_movie_file` through `YTToJellyfin`
- run conversion step in movie download workflow
- document movie conversion in README
- adjust tests for new conversion functionality

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q pyyaml flask requests`
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68473da84d6083239f7d46ab937520fe