### PR TITLE
Add IMDb metadata settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Tubarr is a Python application that downloads YouTube playlists and processes th
 - **H.265 Conversion**: Convert videos to H.265 for better compression and playback performance
 - **Artwork Generation**: Auto-generate show posters, season artwork, and episode thumbnails
 - **TMDb Movie Metadata**: Fetch movie details and posters from The Movie Database when an API key is provided
+- **IMDb Movie Metadata**: Retrieve movie info from IMDb when enabled
 - **Filename Cleaning**: Automatically replaces underscores with spaces in filenames for better readability
 - **Direct Jellyfin Integration**: Optional direct copy to Jellyfin TV library and library scan trigger
 - **Docker Support**: Run as a container in your arr stack or standalone
@@ -189,9 +190,13 @@ You can configure it by editing the `docker-compose.yml` file and the `config/co
 | JELLYFIN_PORT | Jellyfin server port | 8096 |
 | JELLYFIN_API_KEY | Jellyfin API key for triggering library scan (optional) | |
 | TMDB_API_KEY | TMDb API key for enhanced movie metadata (optional) | |
+| IMDB_ENABLED | Enable IMDb metadata provider | false |
+| IMDB_API_KEY | IMDb API key for movie metadata (optional) | |
 
 Set `TMDB_API_KEY` or configure `tmdb.api_key` in `config.yml` to enable
 automatic movie metadata and poster retrieval from The Movie Database.
+Enable IMDb metadata by setting `IMDB_ENABLED` and providing `IMDB_API_KEY` or
+editing the `imdb` section in `config.yml`.
 
 If `YTDLP_PATH` is not provided, Tubarr will search common locations
 (`/usr/local/bin/yt-dlp`, `/usr/bin/yt-dlp`) and fall back to simply

--- a/config/config.yml
+++ b/config/config.yml
@@ -39,6 +39,11 @@ jellyfin:
 tmdb:
   api_key: ""  # Optional TMDb API key for movie metadata
 
+# IMDb Integration
+imdb:
+  enabled: false  # Enable IMDb metadata lookups
+  api_key: ""     # Optional IMDb API key for movie metadata
+
 # Default startup options - override with command parameters
 defaults:
   playlist_url: ""

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -57,6 +57,29 @@ class TestConfigValidation(unittest.TestCase):
             cfg = _load_config()
         self.assertEqual(cfg["tmdb_api_key"], "xyz")
 
+    def test_imdb_enabled_env(self):
+        env = {"IMDB_ENABLED": "true", "IMDB_API_KEY": "key"}
+        with patch.dict(os.environ, env, clear=True), patch(
+            "os.path.exists",
+            side_effect=lambda p: False if p == "config/config.yml" else True,
+        ), patch("os.access", return_value=True):
+            cfg = _load_config()
+        self.assertTrue(cfg["imdb_enabled"])
+        self.assertEqual(cfg["imdb_api_key"], "key")
+
+    def test_imdb_key_file(self):
+        env = {}
+        file_cfg = {"imdb": {"enabled": True, "api_key": "xyz"}}
+        with patch.dict(os.environ, env, clear=True), patch(
+            "os.path.exists",
+            return_value=True,
+        ), patch("builtins.open", mock_open(read_data=yaml.dump(file_cfg))), patch(
+            "os.access", return_value=True
+        ):
+            cfg = _load_config()
+        self.assertTrue(cfg["imdb_enabled"])
+        self.assertEqual(cfg["imdb_api_key"], "xyz")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tubarr/config.py
+++ b/tubarr/config.py
@@ -28,6 +28,8 @@ class ConfigModel(BaseModel):
     jellyfin_port: int = Field(8096, ge=1, le=65535)
     jellyfin_api_key: str = ""
     tmdb_api_key: str = ""
+    imdb_enabled: bool = False
+    imdb_api_key: str = ""
     clean_filenames: bool = True
     defaults: Optional[Dict[str, str]] = Field(default_factory=dict)
 
@@ -80,6 +82,9 @@ def _load_config() -> Dict:
         "jellyfin_port": os.environ.get("JELLYFIN_PORT", "8096"),
         "jellyfin_api_key": os.environ.get("JELLYFIN_API_KEY", ""),
         "tmdb_api_key": os.environ.get("TMDB_API_KEY", ""),
+        "imdb_enabled": os.environ.get("IMDB_ENABLED", "false").lower()
+        == "true",
+        "imdb_api_key": os.environ.get("IMDB_API_KEY", ""),
         "clean_filenames": os.environ.get("CLEAN_FILENAMES", "true").lower() == "true",
     }
 
@@ -161,6 +166,12 @@ def _load_config() -> Dict:
                 if "tmdb" in file_config and isinstance(file_config["tmdb"], dict):
                     if "api_key" in file_config["tmdb"]:
                         config["tmdb_api_key"] = file_config["tmdb"]["api_key"]
+
+                if "imdb" in file_config and isinstance(file_config["imdb"], dict):
+                    if "enabled" in file_config["imdb"]:
+                        config["imdb_enabled"] = file_config["imdb"]["enabled"]
+                    if "api_key" in file_config["imdb"]:
+                        config["imdb_api_key"] = file_config["imdb"]["api_key"]
 
                 if "update_checker" in file_config and isinstance(
                     file_config["update_checker"], dict

--- a/tubarr/web.py
+++ b/tubarr/web.py
@@ -186,6 +186,8 @@ def config():
                 "jellyfin_port",
                 "jellyfin_api_key",
                 "tmdb_api_key",
+                "imdb_enabled",
+                "imdb_api_key",
                 "clean_filenames",
                 "update_checker_enabled",
                 "update_checker_interval",

--- a/web/static/script.js
+++ b/web/static/script.js
@@ -214,16 +214,29 @@ document.addEventListener('DOMContentLoaded', function() {
     const settingsForm = document.getElementById('settings-form');
     if (settingsForm) {
         // Toggle Jellyfin settings visibility based on enabled state
-        const jellyfinEnabled = document.getElementById('jellyfin_enabled');
-        const jellyfinSettings = document.querySelectorAll('.jellyfin-settings');
+       const jellyfinEnabled = document.getElementById('jellyfin_enabled');
+       const jellyfinSettings = document.querySelectorAll('.jellyfin-settings');
+        const imdbEnabled = document.getElementById('imdb_enabled');
+        const imdbSettings = document.querySelectorAll('.imdb-settings');
         const autoCheck = document.getElementById('auto_check_updates');
         const updateSchedule = document.querySelector('.update-schedule-settings');
         const useH265 = document.getElementById('default_use_h265');
         const concurrencyRow = document.querySelector('.h265-concurrency');
 
-        function toggleJellyfinSettings() {
-            const isEnabled = jellyfinEnabled.checked;
-            jellyfinSettings.forEach(el => {
+       function toggleJellyfinSettings() {
+           const isEnabled = jellyfinEnabled.checked;
+           jellyfinSettings.forEach(el => {
+               if (isEnabled) {
+                   el.style.display = 'flex';
+               } else {
+                   el.style.display = 'none';
+               }
+           });
+       }
+
+        function toggleImdbSettings() {
+            const isEnabled = imdbEnabled.checked;
+            imdbSettings.forEach(el => {
                 if (isEnabled) {
                     el.style.display = 'flex';
                 } else {
@@ -249,14 +262,16 @@ document.addEventListener('DOMContentLoaded', function() {
         }
 
         // Set initial state
-        toggleJellyfinSettings();
-        toggleUpdateSchedule();
-        toggleConcurrency();
+       toggleJellyfinSettings();
+        toggleImdbSettings();
+       toggleUpdateSchedule();
+       toggleConcurrency();
 
         // Add event listener for toggle
-        jellyfinEnabled.addEventListener('change', toggleJellyfinSettings);
-        autoCheck.addEventListener('change', toggleUpdateSchedule);
-        useH265.addEventListener('change', toggleConcurrency);
+       jellyfinEnabled.addEventListener('change', toggleJellyfinSettings);
+        imdbEnabled.addEventListener('change', toggleImdbSettings);
+       autoCheck.addEventListener('change', toggleUpdateSchedule);
+       useH265.addEventListener('change', toggleConcurrency);
         
         // Form submission handler
         settingsForm.addEventListener('submit', function(e) {
@@ -279,7 +294,10 @@ document.addEventListener('DOMContentLoaded', function() {
                 jellyfin_tv_path: document.getElementById('jellyfin_tv_path').value,
                 jellyfin_host: document.getElementById('jellyfin_host').value,
                 jellyfin_port: document.getElementById('jellyfin_port').value,
-                jellyfin_api_key: document.getElementById('jellyfin_api_key').value
+                jellyfin_api_key: document.getElementById('jellyfin_api_key').value,
+                // IMDb settings
+                imdb_enabled: document.getElementById('imdb_enabled').checked,
+                imdb_api_key: document.getElementById('imdb_api_key').value
             };
             
             // Send request to update settings
@@ -1200,11 +1218,20 @@ function loadSettings() {
             document.getElementById('jellyfin_host').value = config.jellyfin_host || '';
             document.getElementById('jellyfin_port').value = config.jellyfin_port || '8096';
             document.getElementById('jellyfin_api_key').value = config.jellyfin_api_key || '';
-            
+
+            // IMDb settings
+            const imdbEnabled = document.getElementById('imdb_enabled');
+            imdbEnabled.checked = config.imdb_enabled === true;
+            document.getElementById('imdb_api_key').value = config.imdb_api_key || '';
+
             // Trigger the toggle to show/hide Jellyfin settings
             if (jellyfinEnabled) {
                 const event = new Event('change');
                 jellyfinEnabled.dispatchEvent(event);
+            }
+            if (imdbEnabled) {
+                const e2 = new Event('change');
+                imdbEnabled.dispatchEvent(e2);
             }
             if (autoCheck) {
                 const ev2 = new Event('change');

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -732,6 +732,25 @@
                                         <input type="number" class="form-control" id="update_interval" name="update_interval" min="5" value="60">
                                     </div>
                                 </div>
+
+                                <!-- Metadata Provider Settings -->
+                                <h6 class="mt-4 mb-3">Metadata Providers</h6>
+
+                                <div class="row mb-3">
+                                    <div class="col-lg-12">
+                                        <div class="form-check form-switch">
+                                            <input class="form-check-input" type="checkbox" id="imdb_enabled" name="imdb_enabled">
+                                            <label class="form-check-label" for="imdb_enabled">Use IMDb for movie metadata</label>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div class="row mb-3 imdb-settings">
+                                    <div class="col-lg-6">
+                                        <label for="imdb_api_key" class="form-label">IMDb API Key</label>
+                                        <input type="text" class="form-control" id="imdb_api_key" name="imdb_api_key">
+                                    </div>
+                                </div>
                                 
                                 <!-- Jellyfin Integration Settings -->
                                 <h6 class="mt-4 mb-3">Jellyfin Integration</h6>


### PR DESCRIPTION
## Summary
- allow IMDb API usage in config
- surface IMDb metadata settings on the web UI
- add env vars IMDB_ENABLED and IMDB_API_KEY to README
- test configuration loader for IMDb settings

## Testing
- `flake8 .`
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_684745bf0c3883239269ad277e4a9748