### PR TITLE
Improve subprocess cleanup

### DIFF
--- a/tests/test_job_management.py
+++ b/tests/test_job_management.py
@@ -321,10 +321,11 @@ class TestJobManagement(unittest.TestCase):
         job.process = proc
         self.app.jobs[job_id] = job
 
-        result = self.app.cancel_job(job_id)
+        with patch("tubarr.jobs.terminate_process") as mock_term:
+            result = self.app.cancel_job(job_id)
 
         self.assertTrue(result)
-        proc.terminate.assert_called_once()
+        mock_term.assert_called_once_with(proc)
         self.assertEqual(job.status, "cancelled")
         self.assertIsNone(job.process)
 

--- a/tubarr/jobs.py
+++ b/tubarr/jobs.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import Dict, List, Optional
 
 from .config import logger
+from .utils import terminate_process
 
 
 class DownloadJob:
@@ -216,12 +217,8 @@ def cancel_job(app, job_id: str) -> bool:
     process = getattr(job, "process", None)
     if process and process.poll() is None:
         try:
-            process.terminate()
-            try:
-                process.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                process.kill()
-        except Exception as e:
+            terminate_process(process)
+        except Exception as e:  # pragma: no cover - best effort cleanup
             logger.error(f"Failed to terminate process for job {job_id}: {e}")
     job.process = None
     job.update(status="cancelled", message="Job cancelled")


### PR DESCRIPTION
## Summary
- add terminate_process helper for safe child-process cleanup
- use terminate_process in job cancellation
- spawn yt-dlp/ffmpeg subprocesses in their own sessions
- adjust tests for new cleanup behavior

## Testing
- `flake8 .`
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6847553fe66083239482bfae6bd69dd1